### PR TITLE
fix(ci): reorder predictions-pipeline dispatch above PSR + bump pak cache (#49)

### DIFF
--- a/.github/workflows/predictions-pipeline.yml
+++ b/.github/workflows/predictions-pipeline.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup R dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          cache-version: 1
+          cache-version: 2
           extra-packages: |
             any::devtools
             any::piggyback
@@ -186,24 +186,6 @@ jobs:
             if (isTRUE(pipeline_failed)) quit(status = 1)
           "
 
-      - name: Export weekly PSR snapshots
-        continue-on-error: true
-        timeout-minutes: 50
-        env:
-          PANNADATA_DIR: ${{ runner.temp }}/pannadata
-          GITHUB_PAT: ${{ secrets.WORKFLOW_PAT }}
-        run: |
-          cat > /tmp/run_psr_weekly.R << 'EOF'
-          pannadata_path <- Sys.getenv("PANNADATA_DIR", "../pannadata/data")
-          opta_path <- file.path(pannadata_path, "opta")
-          devtools::load_all()
-          pannadata_dir(pannadata_path)
-          opta_data_dir(opta_path)
-          start_step <- "8b"
-          source("data-raw/estimated-skills/run_skills_pipeline.R")
-          EOF
-          Rscript /tmp/run_psr_weekly.R
-
       - name: Pipeline summary
         if: always()
         run: |
@@ -230,3 +212,21 @@ jobs:
           gh api repos/peteowen1/pannadata/dispatches \
             -f event_type=predictions-complete
           echo "Triggered build-blog-data.yml in pannadata"
+
+      - name: Export weekly PSR snapshots
+        continue-on-error: true
+        timeout-minutes: 50
+        env:
+          PANNADATA_DIR: ${{ runner.temp }}/pannadata
+          GITHUB_PAT: ${{ secrets.WORKFLOW_PAT }}
+        run: |
+          cat > /tmp/run_psr_weekly.R << 'EOF'
+          pannadata_path <- Sys.getenv("PANNADATA_DIR", "../pannadata/data")
+          opta_path <- file.path(pannadata_path, "opta")
+          devtools::load_all()
+          pannadata_dir(pannadata_path)
+          opta_data_dir(opta_path)
+          start_step <- "8b"
+          source("data-raw/estimated-skills/run_skills_pipeline.R")
+          EOF
+          Rscript /tmp/run_psr_weekly.R


### PR DESCRIPTION
Closes #49.

## Summary

- **Reorder** `Trigger blog data build` and `Pipeline summary` steps above `Export weekly PSR snapshots` in `.github/workflows/predictions-pipeline.yml`. PSR is an independent weekly snapshot side job and should not gate the downstream blog refresh chain.
- **Bump** `setup-r-dependencies@v2` `cache-version: 1 → 2` to force a clean pak resolve for the scheduled weekly runs.

## Why

Two distinct problems converged to silently break the football blog data refresh chain between 2026-04-08 and 2026-04-13:

### 1. Dispatch step silently skipped on PSR cancellation

On the 04-12 manual `workflow_dispatch` run [24295183054](https://github.com/peteowen1/panna/actions/runs/24295183054):

| Step | Conclusion |
|---|---|
| Run predictions pipeline (all 10 R steps, uploads to `predictions-latest` + `blog-latest`) | ✅ success |
| Export weekly PSR snapshots | 🚫 cancelled |
| Pipeline summary (`if: always()`) | ⏭️ skipped |
| **Trigger blog data build** (`if: success()`) | ⏭️ **skipped** ← bug |

The predictions work **fully succeeded** — all uploads landed on the pannadata releases. But because the independent PSR snapshot step was cancelled, the `if: success()` gate on the dispatch step evaluated false, and the `repository_dispatch: predictions-complete` to `pannadata` never fired. Result: `pannadata/build-blog-data.yml` never rebuilt the blog parquets, and the football site served stale 04-08 data for 6 days.

Moving the dispatch step above PSR (but keeping it after the `Pipeline summary` validation gate) ensures the dispatch fires as soon as predictions are validated, regardless of what happens in the independent PSR side job.

### 2. Scheduled runs failing at pak resolver

Every scheduled weekly run since 2026-03-18 has died in ~18 seconds at `r-lib/actions/setup-r-dependencies@v2` with `Could not solve package dependencies` from the pak subprocess. Example: run [24127518493](https://github.com/peteowen1/panna/actions/runs/24127518493). The 04-12 manual run got past this because it used a cached environment. Bumping `cache-version` forces a clean resolve on the next scheduled run.

## Risk

Low. The reorder doesn't change any step's behavior — the dispatch step still runs on `if: success()`, still happens after the Pipeline summary validation gate, still uses the same env vars and command. PSR runs strictly later in the sequence now, which is where it always semantically belonged.

The `cache-version` bump may cause one slow run (~10 min for full dep install) before caching kicks back in — standard practice.

## Test plan

- [ ] Merge and watch the next scheduled run on Wed 2026-04-15 08:00 UTC
- [ ] Confirm setup-r-dependencies completes cleanly (pak resolves)
- [ ] Confirm dispatch step fires regardless of PSR outcome
- [ ] Confirm pannadata/build-blog-data.yml is triggered and blog parquets refresh