### PR TITLE
docs: drop FBref pipeline references from active docs

### DIFF
--- a/DATA_DICTIONARY.md
+++ b/DATA_DICTIONARY.md
@@ -4,7 +4,7 @@ This document describes all data structures used in the panna pipelines.
 
 ## Pipeline Overview
 
-### Opta RAPM/SPM Pipeline (Primary) — `data-raw/player-ratings-opta/`
+### RAPM/SPM Pipeline — `data-raw/player-ratings-opta/`
 
 ```
 01_load_opta_data.R       ->  cache-opta/01_opta_data.rds
@@ -17,19 +17,6 @@ This document describes all data structures used in the panna pipelines.
 07b_player_centrality.R   ->  cache-opta/07b_centrality.rds
 08_panna_ratings.R        ->  cache-opta/08_panna_ratings.rds
 09_export_ratings.R       ->  seasonal_xrapm.parquet, seasonal_spm.parquet
-```
-
-### FBref RAPM/SPM Pipeline (Secondary) — `data-raw/player-ratings-fbref/`
-
-```
-01_load_pannadata.R       ->  cache/01_raw_data.rds
-02_data_processing.R      ->  cache/02_processed_data.rds
-03_splint_creation.R      ->  cache/03_splints.rds
-04_rapm.R                 ->  cache/04_rapm.rds
-05_spm.R                  ->  cache/05_spm.rds
-06_xrapm.R                ->  cache/06_xrapm.rds
-07_seasonal_ratings.R     ->  cache/07_seasonal_ratings.rds
-08_panna_ratings.R        ->  cache/08_panna_ratings.rds
 ```
 
 ### EPV/WPA Pipeline — `data-raw/epv/`

--- a/R/panna_rating.R
+++ b/R/panna_rating.R
@@ -230,11 +230,8 @@ fit_panna_model <- function(splint_data, player_features, min_minutes = 180,
 #' Extracts the final panna ratings from a fitted panna model object.
 #' Requires a model fitted with \code{\link{fit_panna_model}}.
 #'
-#' To generate ratings, run one of the pipeline scripts:
-#' \itemize{
-#'   \item Opta (15 leagues): \code{source("data-raw/player-ratings-opta/run_pipeline_opta.R")}
-#'   \item FBref (Big 5): \code{source("data-raw/player-ratings-fbref/run_pipeline.R")}
-#' }
+#' To generate ratings, run the Opta pipeline:
+#' \code{source("data-raw/player-ratings-opta/run_pipeline_opta.R")}
 #'
 #' @param panna_model Fitted panna model from \code{\link{fit_panna_model}}.
 #'

--- a/man/get_panna_ratings.Rd
+++ b/man/get_panna_ratings.Rd
@@ -17,11 +17,8 @@ Extracts the final panna ratings from a fitted panna model object.
 Requires a model fitted with \code{\link{fit_panna_model}}.
 }
 \details{
-To generate ratings, run one of the pipeline scripts:
-\itemize{
-\item Opta (15 leagues): \code{source("data-raw/player-ratings-opta/run_pipeline_opta.R")}
-\item FBref (Big 5): \code{source("data-raw/player-ratings-fbref/run_pipeline.R")}
-}
+To generate ratings, run the Opta pipeline:
+\code{source("data-raw/player-ratings-opta/run_pipeline_opta.R")}
 }
 \examples{
 \dontrun{


### PR DESCRIPTION
## Summary

Follow-up to #51. Three active doc surfaces still advertised the FBref pipeline as live even though it was archived in 43ea7fd.

- `R/panna_rating.R:236` — `get_panna_ratings()` roxygen pointed at `data-raw/player-ratings-fbref/run_pipeline.R` (path no longer exists)
- `man/get_panna_ratings.Rd` — auto-generated counterpart of the above (would have regenerated cleanly from `devtools::document()`)
- `DATA_DICTIONARY.md:7-32` — Pipeline Overview listed FBref as "(Secondary)" and Opta as "(Primary)"; with FBref archived, the distinction is stale

## Scope note

The `## FBref Pipeline Data Structures` section at `DATA_DICTIONARY.md:80+` (match_url, player_href schemas etc.) is intentionally left alone — it documents archived data schemas for historical reference. Can be removed or marked as archived in a separate PR if preferred.

## Test plan

- [x] `grep -r 'data-raw/player-ratings-fbref' R/ man/ DATA_DICTIONARY.md` returns no active references after this PR
- [ ] Opta-only phrasing reads correctly in rendered pkgdown site (verify after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)