### PR TITLE
docs: mark FBref schemas section as archived

### DIFF
--- a/DATA_DICTIONARY.md
+++ b/DATA_DICTIONARY.md
@@ -79,6 +79,8 @@ This document describes all data structures used in the panna pipelines.
 
 ## FBref Pipeline Data Structures
 
+> **Archived in commit 43ea7fd** — the FBref pipeline code was moved to `archive/data-raw/player-ratings-fbref/` and is no longer actively maintained. These schemas are kept for historical reference (e.g. when reading older pannadata releases). The active player ratings pipeline is Opta-based — see **Pipeline Overview** above.
+
 The FBref pipeline shares the same RAPM/SPM methodology as Opta but uses FBref data.
 
 ### 01_raw_data.rds


### PR DESCRIPTION
## Summary

Adds a blockquote banner at the top of `## FBref Pipeline Data Structures` (DATA_DICTIONARY.md:80+) explaining that the FBref pipeline has been archived. The schema tables underneath are kept as-is for historical reference.

## Context

Follow-up to #51 (workflow deletion) and #52 (pipeline-overview doc cleanup). This covers the remaining stale FBref references in `DATA_DICTIONARY.md` — specifically the ~400 lines of schema documentation that still describe tables flowing through the archived pipeline.

## Why keep the schemas?

Old pannadata releases produced by the FBref pipeline still exist in R2 / on disk. If anyone ever reads them, these schema docs are the authoritative reference. Deletion would lose useful information; the banner warns readers the pipeline itself is archived without forcing them to go elsewhere for the column definitions.

## Test plan

- [x] 2-line insertion, trivial diff
- [ ] Render DATA_DICTIONARY.md on GitHub after merge; verify banner renders as a proper blockquote callout

🤖 Generated with [Claude Code](https://claude.com/claude-code)