### PR TITLE
fix(pkgdown): remove all dead FBref/Understat/orphan reference index entries

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -45,13 +45,6 @@ reference:
   - load_opta_skills
   - load_opta_match_stats
 
-- title: Data Loading - Understat
-  desc: Load Understat data (xGChain, xGBuildup)
-  contents:
-  - load_understat_roster
-  - load_understat_shots
-  - load_understat_metadata
-
 - title: Data Loading - FBref
   desc: Load FBref match data from pannadata (StatsBomb xG)
   contents:

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -45,18 +45,6 @@ reference:
   - load_opta_skills
   - load_opta_match_stats
 
-- title: Data Loading - FBref
-  desc: Load FBref match data from pannadata (StatsBomb xG)
-  contents:
-  - load_summary
-  - load_passing
-  - load_defense
-  - load_possession
-  - load_keeper
-  - load_shots
-  - load_metadata
-  - load_events
-
 - title: Player Statistics
   desc: Aggregated player statistics by source
   contents:
@@ -71,12 +59,6 @@ reference:
   - player_opta_xpass
   - player_opta_chains
   - compare_players
-  - player_understat_summary
-  - player_fbref_summary
-  - player_fbref_passing
-  - player_fbref_defense
-  - player_fbref_keeper
-  - player_profile
 
 - title: RAPM Pipeline
   desc: Regularized Adjusted Plus-Minus model
@@ -267,51 +249,17 @@ reference:
   - pb_upload_source
   - pb_upload_data
   - pb_upload_parquet
-  - pb_upload_consolidated
   - pb_sync_data
   - pb_list_data
   - pb_list_sources
   - pb_status
   - load_predictions
 
-- title: Scraping - FBref
-  desc: FBref data scraping functions
-  contents:
-  - scrape_fbref_matches
-  - scrape_comp_season
-  - scrape_fixtures
-  - fbref_competitions
-  - list_competitions
-
-- title: Scraping - Understat
-  desc: Understat data scraping functions
-  contents:
-  - scrape_understat_season
-  - scrape_understat_matches
-  - scrape_understat_match
-  - scrape_understat_match_range
-  - scrape_understat_fixtures
-  - bulk_scrape_understat
-  - smart_scrape_understat
-  - load_understat_manifest
-  - save_understat_manifest
-  - understat_competitions
-  - list_understat_competitions
-
 - title: Cache Management
   desc: Local and remote cache operations
   contents:
   - pannadata_dir
   - opta_data_dir
-  - clear_remote_cache
-
-- title: Parquet Operations
-  desc: Building and querying parquet files
-  contents:
-  - build_parquet
-  - build_all_parquet
-  - build_consolidated_parquet
-  - build_consolidated_understat_parquet
 
 - title: Utilities
   desc: Helper functions
@@ -321,7 +269,6 @@ reference:
   - per_90
   - validate_seasons
   - validate_dataframe
-  - get_big5_leagues
 
 - title: Competition Metadata
   desc: League and competition information
@@ -344,7 +291,6 @@ reference:
   contents:
   - compare_panna_rapm_spm
   - generate_panna_report
-  - report_season_ranges
 
 - title: Constants
   desc: Package-wide constants and thresholds


### PR DESCRIPTION
## Summary
- \`_pkgdown.yml\` referenced 41 functions whose Rd files do not exist in \`man/\` — \`pkgdown::build_reference_index()\` aborts on the first unknown topic, so the workflow has been red since the panna#56 merge.
- Initial commit dropped only the 3 Understat load topics that appeared in the latest run log. Re-review surfaced that \`build_reference_index\` only reports the *first* dead ref it hits — fixing one would just shift the error to the next.
- Audit of \`_pkgdown.yml\` against \`man/*.Rd\` (including \`\alias{}\` resolution) identified 38 truly missing topics. Per \`panna/CLAUDE.md\` ("Active data source: Opta only. FBref/Understat modules and pipelines are deprecated and slated for archival"), all dead refs are FBref/Understat-related or orphan utilities, so the simplest correct fix is to drop them as a batch.

## What this PR removes

**Sections (entirely):**
- \`Data Loading - FBref\` (8 refs)
- \`Scraping - FBref\` (5 refs)
- \`Scraping - Understat\` (11 refs)
- \`Parquet Operations\` (4 refs — all four were dead; section was empty)

**Entries (within retained sections):**
- \`Player Statistics\`: 6 entries (\`player_understat_summary\`, \`player_fbref_*\` ×4, \`player_profile\`)
- \`Data Distribution\`: \`pb_upload_consolidated\`
- \`Cache Management\`: \`clear_remote_cache\`
- \`Utilities\`: \`get_big5_leagues\`
- \`Analysis & Reporting\`: \`report_season_ranges\`

## Verification
After: 187 topics in \`_pkgdown.yml\`, 0 missing from \`man/\`. Verified with:
\`\`\`bash
python -c "import re,os,glob;y=open('_pkgdown.yml').read();t=re.findall(r'^\s+-\s+([a-zA-Z_][a-zA-Z0-9_.]+)\s*$',y,re.M);r={os.path.basename(p)[:-3] for p in glob.glob('man/*.Rd')};a=set();[a.update(re.findall(r'\\alias\{([^}]+)\}',open(rd,encoding='utf-8').read())) for rd in glob.glob('man/*.Rd')];print('missing:',[x for x in t if x not in r|a])"
# missing: []
\`\`\`

## Test plan
- [ ] pkgdown workflow goes green on merge
- [ ] No archived/missing functions remain in \`_pkgdown.yml\`
- [ ] No regression in pkgdown site articles (Understat is also referenced in vignettes/getting-started.Rmd, vignettes/data-sources.Rmd, NEWS.md, README.md — verified those don't run live R, only descriptive text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)