### PR TITLE
fix(pkgdown): add 4 exported helpers missing from reference index

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -68,6 +68,8 @@ reference:
   - fit_rapm
   - fit_rapm_with_prior
   - extract_rapm_ratings
+  - extract_period_end_times
+  - extract_player_timing_from_events
 
 - title: SPM Pipeline
   desc: Statistical Plus-Minus model
@@ -124,6 +126,7 @@ reference:
   desc: Action-level player valuation from Opta event data
   contents:
   - convert_opta_to_spadl
+  - get_or_build_spadl
   - fit_epv_model
   - calculate_action_epv
   - assign_epv_credit
@@ -276,6 +279,7 @@ reference:
   - list_opta_seasons
   - list_opta_leagues
   - get_opta_columns
+  - resolve_league_season
 
 - title: Validation
   desc: Model and data validation


### PR DESCRIPTION
## Summary
- Follow-up to #64. After merging that PR, pkgdown still failed: \`In _pkgdown.yml, 4 topics missing from index: "extract_period_end_times", "extract_player_timing_from_events", "get_or_build_spadl", and "resolve_league_season"\`.
- pkgdown enforces a two-way contract: every Rd file must be either listed in the reference index **OR** marked \`@keywords internal\`. PR #64 fixed yml→Rd direction (deleted dead refs); this PR fixes the converse Rd→yml direction.

## Why this wasn't caught in #64
- The audit script in #64 only checked yml entries against \`man/*.Rd\` (one-way). The pkgdown error in the run logs at PR-#64-time also only mentioned the first dead ref it hit. Once that was cleared, pkgdown reached its bidirectional consistency check and surfaced these four.
- Updated audit verifies both directions clean post-merge.

## Mapping (where each landed)
| Function | R file | Section in \`_pkgdown.yml\` |
|---|---|---|
| \`extract_period_end_times\` | \`R/splint_creation.R\` | RAPM Pipeline |
| \`extract_player_timing_from_events\` | \`R/splint_creation.R\` | RAPM Pipeline |
| \`get_or_build_spadl\` | \`R/spadl_conversion.R\` | EPV (Expected Possession Value) |
| \`resolve_league_season\` | \`R/opta_loaders.R\` | Competition Metadata |

All four are exported in NAMESPACE → adding to the index rather than marking internal matches their public-API status.

## Verification
\`\`\`bash
# bidirectional check
python -c "import re,os,glob;y=open('_pkgdown.yml').read();t=set(re.findall(r'^\s+-\s+([a-zA-Z_][a-zA-Z0-9_.]+)\s*$',y,re.M));aliases=set();[aliases.update(re.findall(r'\\alias\{([^}]+)\}',open(rd,encoding='utf-8').read())) for rd in glob.glob('man/*.Rd')];rd={os.path.basename(p)[:-3] for p in glob.glob('man/*.Rd')};missing_man=[x for x in t if x not in rd|aliases];missing_yml=[base for base in rd if base not in t and not any(a in t for a in re.findall(r'\\alias\{([^}]+)\}',open('man/'+base+'.Rd',encoding='utf-8').read())) and '\\keyword{internal}' not in open('man/'+base+'.Rd',encoding='utf-8').read()];print('missing from man:',missing_man);print('missing from yml:',missing_yml)"
# missing from man: []
# missing from yml: []
\`\`\`

## Test plan
- [ ] pkgdown workflow goes green on merge
- [ ] No new dead refs introduced
- [ ] Site rendering for the 4 helpers works correctly under their new sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)