### PR TITLE
fix(epv-training): chunked chain creation + per-chunk feature sampling (fix OOM)

### DIFF
--- a/.github/workflows/epv-pipeline.yml
+++ b/.github/workflows/epv-pipeline.yml
@@ -198,21 +198,11 @@ jobs:
             fi
           fi
 
-          # Upload xMetrics if generated
-          if [ "$EXPORT_XMETRICS" = "true" ]; then
-            XMETRICS_FILE="data-raw/cache/epv/opta_xmetrics.parquet"
-            if [ -f "$XMETRICS_FILE" ]; then
-              if gh release upload opta-latest "$XMETRICS_FILE" --repo peteowen1/pannadata --clobber; then
-                echo "  Uploaded opta_xmetrics.parquet to opta-latest"
-              else
-                echo "::error::Failed to upload opta_xmetrics.parquet to opta-latest release"
-                exit 1
-              fi
-            else
-              echo "::error::EXPORT_XMETRICS=true but $XMETRICS_FILE was not produced"
-              exit 1
-            fi
-          fi
+          # NOTE: opta_xmetrics.parquet is NOT uploaded here. The earlier
+          # "Calculate player xMetrics" step runs data-raw/epv/04_export_xmetrics.R,
+          # which writes to tempdir() and uploads to opta-latest via piggyback
+          # itself. A redundant upload block previously lived here and silently
+          # no-op'd because the file was never at data-raw/cache/epv/.
 
           echo ""
           echo "=== EPV Pipeline Complete ==="

--- a/.github/workflows/epv-pipeline.yml
+++ b/.github/workflows/epv-pipeline.yml
@@ -198,11 +198,8 @@ jobs:
             fi
           fi
 
-          # NOTE: opta_xmetrics.parquet is NOT uploaded here. The earlier
-          # "Calculate player xMetrics" step runs data-raw/epv/04_export_xmetrics.R,
-          # which writes to tempdir() and uploads to opta-latest via piggyback
-          # itself. A redundant upload block previously lived here and silently
-          # no-op'd because the file was never at data-raw/cache/epv/.
+          # xmetrics upload is handled by data-raw/epv/04_export_xmetrics.R
+          # via piggyback; do not re-add here.
 
           echo ""
           echo "=== EPV Pipeline Complete ==="

--- a/.github/workflows/epv-pipeline.yml
+++ b/.github/workflows/epv-pipeline.yml
@@ -30,7 +30,9 @@ env:
 jobs:
   epv-pipeline:
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    # Per-chunk feature generation + xgboost training fits in ~75-90 min on a
+    # 7GB runner; bumped from 90 to 120 to give headroom on slower runners.
+    timeout-minutes: 120
 
     permissions:
       contents: write

--- a/data-raw/epv/01_train_epv_models.R
+++ b/data-raw/epv/01_train_epv_models.R
@@ -41,14 +41,40 @@ cli_h1("EPV Model Training Pipeline")
 cli_alert_info("Leagues: {paste(LEAGUES, collapse = ', ')}")
 cli_alert_info("Seasons: {paste(SEASONS, collapse = ', ')}")
 
-# 2. Load Data & Convert to SPADL (per-league to preserve league tag) ----
+# 2. Load Data, Build Chains, Create Labels (per-chunk to fit in 7GB) ----
+#
+# Streams each (league, season) through the full chain pipeline immediately
+# after loading and writes the labeled output to a per-chunk parquet under
+# cache_dir before moving to the next iteration. Replaces an in-memory
+# `all_spadl` accumulation + a single `create_possession_chains()` on 22M
+# rows — the latter peaked at ~10GB working memory and OOM-killed the
+# 7GB GHA runner. All chain operations are by = match_id, so chunking by
+# (league, season) is safe — chains never span matches.
+#
+# Mirrors the `step-08b` chunk-stream playbook: flat-named chunks under
+# cache_dir (not tempdir, which has been observed to vanish mid-run on
+# GHA), no leading dot (list.files default skips hidden), gc(full = TRUE)
+# every 5th iteration to bound peak.
 
-cli_h2("Step 1: Load Opta Events and Convert to SPADL")
+cli_h2("Step 1: Load Opta + Build Labeled Chains (per-chunk)")
 
-all_spadl <- list()
+LABELED_CHUNKS_DIR <- file.path(CACHE_DIR, "labeled_chunks")
+dir.create(LABELED_CHUNKS_DIR, recursive = TRUE, showWarnings = FALSE)
+
+# Cleanup residue from any prior crashed run before we begin
+.cleanup_labeled_chunks <- function() {
+  files <- list.files(LABELED_CHUNKS_DIR, pattern = "^chunk_.*\\.parquet$", full.names = TRUE)
+  if (length(files) > 0) unlink(files, force = TRUE)
+}
+.cleanup_labeled_chunks()
+
 all_shots <- list()
 all_lineups <- list()
 total_events <- 0L
+total_actions <- 0L
+total_chains <- 0L
+loaded_leagues <- character(0)
+iter_count <- 0L
 
 # Build league → season list (domestic use SEASONS, tournaments use TOURNAMENT_SEASONS)
 league_seasons <- list()
@@ -63,56 +89,82 @@ for (league in LEAGUES) {
 for (league in LEAGUES) {
   for (season in league_seasons[[league]]) {
     key <- paste(league, season)
+    iter_count <- iter_count + 1L
+
+    chunk_name <- sprintf("chunk_%s_%s.parquet",
+                          gsub("[^A-Za-z0-9]", "_", league),
+                          gsub("[^A-Za-z0-9]", "_", season))
+    chunk_path <- file.path(LABELED_CHUNKS_DIR, chunk_name)
 
     tryCatch({
       events <- load_opta_match_events(league, season = season, source = "local")
-      shots <- load_opta_shot_events(league, season = season, source = "local")
+      shot_events <- load_opta_shot_events(league, season = season, source = "local")
       lineups <- load_opta_lineups(league, season = season, source = "local")
 
       # Convert to SPADL and tag with league
-      spadl <- convert_opta_to_spadl(events)
-      spadl$league <- league
+      spadl_chunk <- convert_opta_to_spadl(events)
+      spadl_chunk$league <- league
 
-      all_spadl[[key]] <- spadl
-      all_shots[[key]] <- shots
+      # Run the full chain + label pipeline on just this chunk. Free each
+      # intermediate as soon as the next one is built.
+      chains_chunk <- create_possession_chains(spadl_chunk)
+      rm(spadl_chunk); gc(verbose = FALSE)
+
+      outcomes_chunk <- classify_chain_outcomes(chains_chunk)
+      outcomes_chunk <- add_next_chain_outcome(outcomes_chunk)
+      labeled_chunk <- label_actions_with_outcomes(chains_chunk, outcomes_chunk)
+      rm(chains_chunk); gc(verbose = FALSE)
+
+      labeled_chunk <- create_next_goal_labels(labeled_chunk)
+      if (EPV_METHOD == "xg") {
+        labeled_chunk <- create_next_xg_labels(labeled_chunk)
+      }
+
+      arrow::write_parquet(labeled_chunk, chunk_path)
+
+      all_shots[[key]] <- shot_events
       all_lineups[[key]] <- lineups
       total_events <- total_events + nrow(events)
+      total_actions <- total_actions + nrow(labeled_chunk)
+      total_chains <- total_chains + nrow(outcomes_chunk)
+      loaded_leagues <- union(loaded_leagues, league)
 
-      cli_alert_success("  {key}: {nrow(events)} events -> {nrow(spadl)} SPADL actions")
+      cli_alert_success("  {key}: {format(nrow(events), big.mark=',')} events -> {format(nrow(labeled_chunk), big.mark=',')} labeled actions, {format(nrow(outcomes_chunk), big.mark=',')} chains -> {basename(chunk_path)}")
+
+      rm(labeled_chunk, outcomes_chunk, events, shot_events, lineups)
+      # Full gc every 5 iterations to bound long-running heap creep
+      gc(verbose = FALSE, full = (iter_count %% 5 == 0))
     }, error = function(e) {
       cli_alert_warning("  Skipping {key}: {e$message}")
     })
   }
 }
 
-# Combine
-spadl <- data.table::rbindlist(all_spadl, fill = TRUE)
+# Concat the small per-chunk shots/lineups (these don't OOM — total size is
+# in the hundreds of MB, well below the chain-creation peak).
 shots <- do.call(rbind, all_shots)
 lineups <- do.call(rbind, all_lineups)
+n_leagues_loaded <- length(loaded_leagues)
+rm(all_shots, all_lineups); gc(verbose = FALSE, full = TRUE)
 
-n_leagues_loaded <- length(unique(spadl$league))
-cli_alert_success("Total: {format(total_events, big.mark=',')} events -> {format(nrow(spadl), big.mark=',')} SPADL actions from {n_leagues_loaded} leagues")
+n_chunks <- length(list.files(LABELED_CHUNKS_DIR, pattern = "^chunk_.*\\.parquet$"))
+cli_alert_success("Total: {format(total_events, big.mark=',')} events -> {format(total_actions, big.mark=',')} labeled actions, {format(total_chains, big.mark=',')} chains from {n_leagues_loaded} leagues across {n_chunks} chunks")
 
-# 3. Create Possession Chains ----
+# 3. Read Labeled Chunks Back for Downstream Training ----
 
-cli_h2("Step 2: Create Possession Chains")
+cli_h2("Step 2: Materialize labeled actions from chunks for training")
 
-spadl_chains <- create_possession_chains(spadl)
-chain_outcomes <- classify_chain_outcomes(spadl_chains)
-chain_outcomes <- add_next_chain_outcome(chain_outcomes)
-spadl_labeled <- label_actions_with_outcomes(spadl_chains, chain_outcomes)
+# Read all chunks via arrow dataset and collect to a single data.table.
+# By this point the chain-creation working memory has been freed, so the
+# steady-state size of spadl_labeled (~5GB for 22M rows × ~30 cols) fits
+# in the 7GB ceiling. The downstream training steps subsample further to
+# MAX_XPASS_ROWS / MAX_EPV_ROWS, so this is the peak.
+spadl_labeled <- arrow::open_dataset(LABELED_CHUNKS_DIR) |>
+  dplyr::collect() |>
+  data.table::as.data.table()
+gc(verbose = FALSE, full = TRUE)
 
-cli_alert_success("Chains: {nrow(chain_outcomes)} possession sequences")
-
-# 4. Create Labels ----
-
-cli_h2("Step 3: Create Labels ({EPV_METHOD} method)")
-
-spadl_labeled <- create_next_goal_labels(spadl_labeled)
-
-if (EPV_METHOD == "xg") {
-  spadl_labeled <- create_next_xg_labels(spadl_labeled)
-}
+cli_alert_success("Materialized {format(nrow(spadl_labeled), big.mark=',')} labeled actions from {n_chunks} chunks")
 
 # 5. Train xG Model ----
 
@@ -131,7 +183,7 @@ saveRDS(xg_model, file.path(CACHE_DIR, "xg_model.rds"))
 
 cli_h2("Step 5: Train xPass Model")
 
-pass_features <- prepare_passes_for_xpass(spadl)
+pass_features <- prepare_passes_for_xpass(spadl_labeled)
 
 # Subsample if too large for CV (15M+ rows OOMs on xgb.cv)
 MAX_XPASS_ROWS <- 2000000L
@@ -211,4 +263,4 @@ cat("\nFeature Importance (EPV model, top 15):\n")
 print(head(epv_model$importance, 15))
 
 cat("\nLeague distribution in training data:\n")
-print(table(spadl$league))
+print(table(spadl_labeled$league))

--- a/data-raw/epv/01_train_epv_models.R
+++ b/data-raw/epv/01_train_epv_models.R
@@ -61,10 +61,17 @@ cli_h2("Step 1: Load Opta + Build Labeled Chains (per-chunk)")
 LABELED_CHUNKS_DIR <- file.path(CACHE_DIR, "labeled_chunks")
 dir.create(LABELED_CHUNKS_DIR, recursive = TRUE, showWarnings = FALSE)
 
-# Cleanup residue from any prior crashed run before we begin
 .cleanup_labeled_chunks <- function() {
   files <- list.files(LABELED_CHUNKS_DIR, pattern = "^chunk_.*\\.parquet$", full.names = TRUE)
-  if (length(files) > 0) unlink(files, force = TRUE)
+  if (length(files) > 0) {
+    result <- unlink(files, force = TRUE)
+    if (any(result != 0)) {
+      cli::cli_abort(c(
+        "Failed to clean stale chunks under {.path {LABELED_CHUNKS_DIR}}.",
+        "i" = "Refusing to mix stale and fresh data into training."
+      ))
+    }
+  }
 }
 .cleanup_labeled_chunks()
 
@@ -74,6 +81,7 @@ total_events <- 0L
 total_actions <- 0L
 total_chains <- 0L
 loaded_leagues <- character(0)
+failed_keys <- character(0)
 iter_count <- 0L
 
 # Build league → season list (domestic use SEASONS, tournaments use TOURNAMENT_SEASONS)
@@ -136,19 +144,38 @@ for (league in LEAGUES) {
       gc(verbose = FALSE, full = (iter_count %% 5 == 0))
     }, error = function(e) {
       cli_alert_warning("  Skipping {key}: {e$message}")
+      failed_keys <<- c(failed_keys, key)
     })
   }
 }
 
-# Concat the small per-chunk shots/lineups (these don't OOM — total size is
-# in the hundreds of MB, well below the chain-creation peak).
-shots <- do.call(rbind, all_shots)
-lineups <- do.call(rbind, all_lineups)
+# Concat the small per-chunk shots/lineups — they don't get chain-expanded
+# so they fit easily.
+shots <- data.table::rbindlist(all_shots, fill = TRUE)
+lineups <- data.table::rbindlist(all_lineups, fill = TRUE)
 n_leagues_loaded <- length(loaded_leagues)
 rm(all_shots, all_lineups); gc(verbose = FALSE, full = TRUE)
 
 n_chunks <- length(list.files(LABELED_CHUNKS_DIR, pattern = "^chunk_.*\\.parquet$"))
 cli_alert_success("Total: {format(total_events, big.mark=',')} events -> {format(total_actions, big.mark=',')} labeled actions, {format(total_chains, big.mark=',')} chains from {n_leagues_loaded} leagues across {n_chunks} chunks")
+
+# Loud failure if no chunks were produced — every (league, season) skipped.
+# Without this, the per-chunk feature loop below silently produces zero-row
+# accumulators and training fails with a confusing error 50+ lines later.
+if (n_chunks == 0L) {
+  cli_abort(c(
+    "No labeled chunks were produced — every (league, season) was skipped.",
+    "i" = "Failed keys ({length(failed_keys)}): {paste(failed_keys, collapse = ', ')}",
+    "i" = "Check the warnings above for the underlying error."
+  ))
+}
+if (length(failed_keys) > iter_count * 0.5) {
+  cli_abort(c(
+    "Too many (league, season) loads failed: {length(failed_keys)} of {iter_count} (>50%).",
+    "i" = "Failed keys: {paste(failed_keys, collapse = ', ')}",
+    "i" = "Refusing to train on partial data."
+  ))
+}
 
 # 3. Per-Chunk Feature Generation + Sampling for Training ----
 #
@@ -187,6 +214,14 @@ pass_features_acc <- vector("list", length(chunk_files))
 set.seed(42)
 for (i in seq_along(chunk_files)) {
   chunk_dt <- arrow::read_parquet(chunk_files[[i]]) |> data.table::as.data.table()
+
+  # Make alignment between epv_features and spadl_labeled explicit. Without
+  # this sort, alignment depended on a side effect: create_epv_features_simple
+  # internally calls setorder() on its input, which mutates chunk_dt in place
+  # because as.data.table() on a data.table returns by reference. Pre-sorting
+  # here means alignment holds even if that internal contract changes (e.g.,
+  # someone adds a defensive data.table::copy() inside the function).
+  data.table::setorder(chunk_dt, match_id, period_id, time_seconds, action_id)
 
   # EPV features (must be created on full chunk because of per-match lags)
   epv_features_chunk <- create_epv_features_simple(chunk_dt) |> data.table::as.data.table()
@@ -227,8 +262,7 @@ if (nrow(pass_features) > MAX_XPASS_ROWS) {
 }
 
 # Convert back to data.frame for downstream model fits. fit_xpass_model uses
-# `[.data.frame` semantics with `drop = FALSE` which data.table doesn't honor
-# the same way (caused the previous validation run to fail at xPass training).
+# `[.data.frame` semantics with `drop = FALSE` that data.table doesn't honor.
 epv_features <- as.data.frame(epv_features)
 spadl_labeled <- as.data.frame(spadl_labeled)
 pass_features <- as.data.frame(pass_features)

--- a/data-raw/epv/01_train_epv_models.R
+++ b/data-raw/epv/01_train_epv_models.R
@@ -226,6 +226,13 @@ if (nrow(pass_features) > MAX_XPASS_ROWS) {
   pass_features <- pass_features[sample(nrow(pass_features), MAX_XPASS_ROWS)]
 }
 
+# Convert back to data.frame for downstream model fits. fit_xpass_model uses
+# `[.data.frame` semantics with `drop = FALSE` which data.table doesn't honor
+# the same way (caused the previous validation run to fail at xPass training).
+epv_features <- as.data.frame(epv_features)
+spadl_labeled <- as.data.frame(spadl_labeled)
+pass_features <- as.data.frame(pass_features)
+
 cli_alert_success("Sampled — epv: {format(nrow(epv_features), big.mark=',')} rows / spadl_labeled: {format(nrow(spadl_labeled), big.mark=',')} rows / pass_features: {format(nrow(pass_features), big.mark=',')} rows")
 
 # 5. Train xG Model ----

--- a/data-raw/epv/01_train_epv_models.R
+++ b/data-raw/epv/01_train_epv_models.R
@@ -150,21 +150,83 @@ rm(all_shots, all_lineups); gc(verbose = FALSE, full = TRUE)
 n_chunks <- length(list.files(LABELED_CHUNKS_DIR, pattern = "^chunk_.*\\.parquet$"))
 cli_alert_success("Total: {format(total_events, big.mark=',')} events -> {format(total_actions, big.mark=',')} labeled actions, {format(total_chains, big.mark=',')} chains from {n_leagues_loaded} leagues across {n_chunks} chunks")
 
-# 3. Read Labeled Chunks Back for Downstream Training ----
+# 3. Per-Chunk Feature Generation + Sampling for Training ----
+#
+# Materializing the full 22M-row spadl_labeled in one shot OOMs at ~10GB on
+# the 7GB runner (arrow buffers + data.table conversion overhead), even after
+# the chain-creation peak is gone. So instead, read one chunk at a time,
+# generate features per-chunk, and accumulate a pre-sampled training set.
+#
+# Why per-chunk for EPV and not row-level after-the-fact: create_epv_features_simple
+# uses shift(..., by = .(match_id, period_id)) for previous-action context.
+# Random row sampling would shred those lags. Per-(league, season) chunks
+# preserve match continuity (chains never span matches), so feature-gen
+# inside the chunk is safe.
+#
+# Why row-level sampling is safe for xPass: create_pass_features is fully
+# vectorized — no shift, no setorder, no by-match operations. Sample
+# anywhere.
 
-cli_h2("Step 2: Materialize labeled actions from chunks for training")
+cli_h2("Step 2: Per-chunk feature generation + sampling")
 
-# Read all chunks via arrow dataset and collect to a single data.table.
-# By this point the chain-creation working memory has been freed, so the
-# steady-state size of spadl_labeled (~5GB for 22M rows × ~30 cols) fits
-# in the 7GB ceiling. The downstream training steps subsample further to
-# MAX_XPASS_ROWS / MAX_EPV_ROWS, so this is the peak.
-spadl_labeled <- arrow::open_dataset(LABELED_CHUNKS_DIR) |>
-  dplyr::collect() |>
-  data.table::as.data.table()
-gc(verbose = FALSE, full = TRUE)
+MAX_XPASS_ROWS <- 2000000L
+MAX_EPV_ROWS <- 5000000L
 
-cli_alert_success("Materialized {format(nrow(spadl_labeled), big.mark=',')} labeled actions from {n_chunks} chunks")
+chunk_files <- list.files(LABELED_CHUNKS_DIR, pattern = "^chunk_.*\\.parquet$", full.names = TRUE)
+# 5% / 10% overshoot so the per-chunk ceiling absorbs uneven chunk sizes;
+# we trim to exact targets after the loop.
+epv_target_per_chunk <- ceiling(MAX_EPV_ROWS / length(chunk_files) * 1.05)
+xpass_target_per_chunk <- ceiling(MAX_XPASS_ROWS / length(chunk_files) * 1.10)
+
+cli_alert_info("Per-chunk targets: EPV {format(epv_target_per_chunk, big.mark=',')} rows, xPass {format(xpass_target_per_chunk, big.mark=',')} rows × {length(chunk_files)} chunks")
+
+epv_features_acc <- vector("list", length(chunk_files))
+spadl_labeled_acc <- vector("list", length(chunk_files))
+pass_features_acc <- vector("list", length(chunk_files))
+
+set.seed(42)
+for (i in seq_along(chunk_files)) {
+  chunk_dt <- arrow::read_parquet(chunk_files[[i]]) |> data.table::as.data.table()
+
+  # EPV features (must be created on full chunk because of per-match lags)
+  epv_features_chunk <- create_epv_features_simple(chunk_dt) |> data.table::as.data.table()
+  if (nrow(chunk_dt) > 0) {
+    n_take <- min(epv_target_per_chunk, nrow(chunk_dt))
+    sample_idx <- sample(nrow(chunk_dt), n_take)
+    epv_features_acc[[i]] <- epv_features_chunk[sample_idx]
+    spadl_labeled_acc[[i]] <- chunk_dt[sample_idx]
+  }
+  rm(epv_features_chunk)
+
+  # xPass features (vectorized, safe to sample after generation)
+  passes_chunk <- chunk_dt[action_type == "pass"]
+  if (nrow(passes_chunk) > 0) {
+    pass_features_chunk <- prepare_passes_for_xpass(passes_chunk) |> data.table::as.data.table()
+    n_take <- min(xpass_target_per_chunk, nrow(pass_features_chunk))
+    pass_features_acc[[i]] <- pass_features_chunk[sample(nrow(pass_features_chunk), n_take)]
+    rm(pass_features_chunk)
+  }
+  rm(chunk_dt, passes_chunk)
+  if (i %% 5 == 0) gc(verbose = FALSE, full = TRUE)
+}
+
+# Concatenate samples
+epv_features <- data.table::rbindlist(epv_features_acc, fill = TRUE)
+spadl_labeled <- data.table::rbindlist(spadl_labeled_acc, fill = TRUE)
+pass_features <- data.table::rbindlist(pass_features_acc, fill = TRUE)
+rm(epv_features_acc, spadl_labeled_acc, pass_features_acc); gc(verbose = FALSE, full = TRUE)
+
+# Trim to exact targets if per-chunk overshoot pushed us over
+if (nrow(epv_features) > MAX_EPV_ROWS) {
+  trim_idx <- sample(nrow(epv_features), MAX_EPV_ROWS)
+  epv_features <- epv_features[trim_idx]
+  spadl_labeled <- spadl_labeled[trim_idx]
+}
+if (nrow(pass_features) > MAX_XPASS_ROWS) {
+  pass_features <- pass_features[sample(nrow(pass_features), MAX_XPASS_ROWS)]
+}
+
+cli_alert_success("Sampled — epv: {format(nrow(epv_features), big.mark=',')} rows / spadl_labeled: {format(nrow(spadl_labeled), big.mark=',')} rows / pass_features: {format(nrow(pass_features), big.mark=',')} rows")
 
 # 5. Train xG Model ----
 
@@ -183,16 +245,8 @@ saveRDS(xg_model, file.path(CACHE_DIR, "xg_model.rds"))
 
 cli_h2("Step 5: Train xPass Model")
 
-pass_features <- prepare_passes_for_xpass(spadl_labeled)
-
-# Subsample if too large for CV (15M+ rows OOMs on xgb.cv)
-MAX_XPASS_ROWS <- 2000000L
-if (nrow(pass_features) > MAX_XPASS_ROWS) {
-  set.seed(42)
-  pass_features <- pass_features[sample(nrow(pass_features), MAX_XPASS_ROWS), ]
-  cli_alert_info("Subsampled xPass training data to {format(MAX_XPASS_ROWS, big.mark=',')} rows")
-}
-
+# pass_features was generated and sampled per-chunk in Step 2 to bound peak
+# memory. Subsampling here would be redundant.
 xpass_model <- fit_xpass_model(pass_features,
                                 nrounds = XGB_PARAMS$nrounds,
                                 early_stopping_rounds = XGB_PARAMS$early_stopping_rounds,
@@ -205,18 +259,8 @@ saveRDS(xpass_model, file.path(CACHE_DIR, "xpass_model.rds"))
 
 cli_h2("Step 6: Train EPV Model (simple features)")
 
-epv_features <- create_epv_features_simple(spadl_labeled)
-
-# Subsample if too large for CV (21M+ rows can OOM on xgb.cv)
-MAX_EPV_ROWS <- 5000000L
-if (nrow(epv_features) > MAX_EPV_ROWS) {
-  set.seed(42)
-  sample_idx <- sample(nrow(epv_features), MAX_EPV_ROWS)
-  epv_features <- epv_features[sample_idx, ]
-  spadl_labeled <- spadl_labeled[sample_idx, ]
-  cli_alert_info("Subsampled EPV training data to {format(MAX_EPV_ROWS, big.mark=',')} rows")
-}
-
+# epv_features and spadl_labeled were generated and aligned-sampled per-chunk
+# in Step 2 to bound peak memory. Subsampling here would be redundant.
 epv_model <- fit_epv_model(epv_features, spadl_labeled,
                             method = EPV_METHOD,
                             nrounds = XGB_PARAMS$nrounds,


### PR DESCRIPTION
## 🟢 Repairs end-to-end opta-pipeline chain — validated in production

The Opta RAPM/SPM Pipeline has been red for 30+ runs because \`opta_xmetrics.parquet\` on the opta-latest release was stale (last refreshed 2026-02-28). The previous PR #68 fixed the release-tag drift and added a freshness gate, but EPV training itself OOM'd on the 7GB \`ubuntu-latest\` runner — meaning xmetrics couldn't be regenerated.

This PR chunks the EPV training pipeline so it fits in 7GB. **Validated end-to-end via 4 dispatch-and-iterate runs on \`dev\`** — final run completed all training steps and uploaded fresh xmetrics:

\`\`\`
opta_xmetrics.parquet: 2026-05-03T12:00:25Z, 11.5 MB
                       (was: 2026-02-28T01:10:11Z, 10.0 MB — stale 65 days)
\`\`\`

The next opta-pipeline run will pass the freshness gate.

## Four coupled fixes

### 1. Chunked chain creation (\`9cc9bfa\`)
\`create_possession_chains(spadl)\` on 22M rows peaked at ~10GB working memory and OOM-killed the runner. All chain operations are \`by = match_id\`, so chunking by (league, season) is safe — chains never span matches.

Refactor: inside the existing load loop, run the full chain + label pipeline on just that chunk and stream the labeled output to \`data-raw/cache/epv/labeled_chunks/\`. Mirrors the \`step-08b\` chunk-stream playbook from earlier panna commits — flat-named chunks under cache_dir (not tempdir, observed to vanish mid-run on GHA), no leading dot, cleanup function at start, gc(full = TRUE) every 5 iterations.

**Validated:** 28.4M events → 21.9M labeled actions, 6.4M chains across 55 chunks in ~5 min, no OOM.

### 2. Per-chunk feature generation + sampling (\`26c6e80\`)
The post-loop \`arrow::open_dataset() |> collect()\` of 22M labeled rows still OOM'd at materialize (~10GB peak from arrow buffers + data.table conversion).

Fix: don't materialize the full corpus. Read one chunk at a time, generate \`epv_features\` and \`pass_features\` per-chunk, sample within the loop, accumulate the sampled training set. Subsampling is **after** feature generation for EPV (because \`create_epv_features_simple\` uses \`shift(..., by = .(match_id, period_id))\`) and **after** \`prepare_passes_for_xpass\` for xPass (which is fully vectorized — no lags, safe to sample anywhere).

Per-chunk targets sized so per-chunk × n_chunks slightly overshoots MAX_*_ROWS; trim to exact at the end.

**Validated:** epv 5,000,000 rows / spadl_labeled 5,000,000 rows / pass_features 2,000,000 rows produced in ~1 min without OOM.

### 3. data.frame coercion before model fit (\`3a3a767\`)
\`fit_xpass_model\` uses \`[.data.frame\` semantics with \`drop = FALSE\` which data.table doesn't honor the same way. My per-chunk refactor's explicit \`as.data.table()\` coercions propagated through \`rbindlist\` and broke training. Defensive \`as.data.frame()\` on all three sampled tables (epv_features, spadl_labeled, pass_features) after trim.

### 4. Drop redundant workflow xmetrics upload (\`1c5c839\`)
The R script \`data-raw/epv/04_export_xmetrics.R\` writes to \`tempdir()\` and uploads to opta-latest via \`piggyback::pb_upload\` itself. The workflow's separate \`gh release upload opta-latest "data-raw/cache/epv/opta_xmetrics.parquet"\` block was always either silently no-op'ing (original \`[ -f ]\` guard) or loud-failing (after the review-feedback strictening). Removed; comment added so the next maintainer doesn't re-add it.

## Other workflow tweak
Bumped \`epv-pipeline.yml\` \`timeout-minutes\` from 90 to 120 since per-chunk feature generation adds ~10-15 min to the run.

## Validation cadence

| Run | Outcome |
|---|---|
| [25267496173](https://github.com/peteowen1/panna/actions/runs/25267496173) | failed at 6m53s — file layout mismatch (fixed in PR #68) |
| [25268248773](https://github.com/peteowen1/panna/actions/runs/25268248773) | failed at 14m19s — OOM at create_possession_chains |
| [25276226317](https://github.com/peteowen1/panna/actions/runs/25276226317) | failed at 17m26s — OOM at materialize-from-chunks |
| [25276694816](https://github.com/peteowen1/panna/actions/runs/25276694816) | failed at 16m21s — data.table type mismatch in fit_xpass_model |
| [25277067101](https://github.com/peteowen1/panna/actions/runs/25277067101) | training ✓, xmetrics export ✓, only failed at the redundant workflow upload (now removed) |

The chain is **functionally repaired** as of [25277067101]'s xmetrics upload. This PR's final commit just removes the spurious workflow YAML failure.

## Test plan

- [x] xmetrics on opta-latest is fresh (verified: 2026-05-03T12:00:25Z, 11.5 MB)
- [ ] After merge, dispatch one more EPV training run on main to confirm no regressions in the cleaned-up workflow.
- [ ] Trigger opta-pipeline (workflow_dispatch) — should pass the freshness gate and run the full RAPM/SPM pipeline.
- [ ] ops/Actions Health Check shows panna/Opta RAPM/SPM Pipeline in green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)