### PR TITLE
Rename action_equity column: equity -> epv_credit (10c export)

### DIFF
--- a/data-raw/epv/06_export_xg_model_json.R
+++ b/data-raw/epv/06_export_xg_model_json.R
@@ -1,0 +1,39 @@
+#!/usr/bin/env Rscript
+# Export the xG model (panna/R/xg_model.R, data-raw/cache/epv/xg_model.rds) to
+# JSON for the Cloudflare Worker's live shot-xG scoring. Mirrors
+# 05c_export_epv_model_json.R. Binary:logistic goal classifier; the worker's
+# tree walker scores it as sigmoid(sum + logit(base_score)).
+suppressMessages({ library(xgboost); library(jsonlite) })
+
+rds <- "data-raw/cache/epv/xg_model.rds"
+out <- if (length(commandArgs(trailingOnly = TRUE)) >= 1) commandArgs(trailingOnly = TRUE)[1] else "xg-model.json"
+if (!file.exists(rds)) stop("Missing xG model: ", rds)
+
+obj <- readRDS(rds)
+booster <- obj$model
+feature_names <- obj$panna_metadata$feature_cols
+cat("features (", length(feature_names), "):", paste(feature_names, collapse = ", "), "\n")
+
+tmp <- tempfile(fileext = ".json")
+xgb.dump(booster, fname = tmp, dump_format = "json")
+trees <- fromJSON(tmp, simplifyDataFrame = FALSE, simplifyVector = FALSE)
+cat("trees:", length(trees), "\n")
+
+cfg <- xgb.config(booster)
+if (is.character(cfg)) cfg <- fromJSON(cfg, simplifyDataFrame = FALSE, simplifyVector = FALSE)
+obj_name <- cfg$learner$objective$name
+bs_raw <- cfg$learner$learner_model_param$base_score
+base_score <- as.numeric(gsub("[][]", "", bs_raw))  # strip [ ] brackets
+cat("objective:", obj_name, "| base_score:", round(base_score, 6), "\n")
+
+envelope <- list(
+  model_type = "xg_soccer",
+  objective = obj_name,
+  num_class = 1L,
+  feature_names = feature_names,
+  nrounds = length(trees),
+  base_score = base_score,
+  trees = trees
+)
+write_json(envelope, out, auto_unbox = TRUE, digits = 10)
+cat("wrote", out, "size:", file.info(out)$size, "bytes\n")

--- a/data-raw/match-predictions-opta/10c_export_equity.R
+++ b/data-raw/match-predictions-opta/10c_export_equity.R
@@ -1,17 +1,22 @@
 # 10c_export_equity.R
-# Export per-action EPV credit (equity) for the blog match-events page
+# Export per-action EPV credit for the blog match-events page
 #
 # Produces action_equity_<season>.parquet — one parquet per season — with a
-# slim lookup of (match_id, event_id, equity) for every SPADL action. The
-# pannadata chain builder joins this onto chain parquets as the `equity`
+# slim lookup of (match_id, event_id, epv_credit) for every SPADL action. The
+# pannadata chain builder joins this onto chain parquets as the `epv_credit`
 # column for per-action visualisation.
+#
+# The column is `epv_credit` (renamed from `equity` 2026-06-03): it holds
+# per-action player CREDIT (sum it; never diff it), distinct from the worker's
+# `equity` field which is an EPV STATE. The old name collided with that state
+# meaning. The file name (action_equity.parquet) is unchanged.
 #
 # Default: current season only (weekly predictions pipeline). For historical
 # backfill, set `equity_seasons <- c("2015-2016", ..., "2025-2026")` before
 # sourcing — see 10c_backfill_action_equity.R.
 #
 # Pipeline per season:
-#   events → SPADL (cached) → chains → EPV → credit → (match_id, event_id, equity)
+#   events → SPADL (cached) → chains → EPV → credit → (match_id, event_id, epv_credit)
 #
 # Cup competitions (UCL/UEL/UECL and WC/EURO where available) are included
 # via resolve_league_season(), matching 10b_export_game_logs.R.
@@ -77,7 +82,7 @@ skip_league_cond <- function(reason) {
 
 # Minimum columns the slim equity lookup must emit. Catches drift in the
 # SPADL credit assignment before we ship a malformed parquet.
-.required_equity_cols <- c("match_id", "event_id", "equity")
+.required_equity_cols <- c("match_id", "event_id", "epv_credit")
 
 validate_equity_schema <- function(dt, league, season) {
   missing <- setdiff(.required_equity_cols, names(dt))
@@ -134,9 +139,9 @@ validate_equity_schema <- function(dt, league, season) {
       # (synthetic SPADL actions like merged duels).
       dt <- data.table::as.data.table(spadl_credit)
       equity <- dt[, .(
-        match_id = match_id,
-        event_id = original_event_id,
-        equity   = round(player_credit, 4)
+        match_id   = match_id,
+        event_id   = original_event_id,
+        epv_credit = round(player_credit, 4)   # per-action credit (sum, don't diff)
       )]
       equity <- equity[!is.na(event_id) & event_id != ""]
 


### PR DESCRIPTION
## Summary
Renames the `action_equity.parquet` export column `equity` → `epv_credit` in `10c_export_equity.R`. The column holds per-action player **credit** (`player_credit` ≈ `epv_delta`), which collided with the worker's `equity` = EPV **state** field and produced a false "corrupt join" alarm. `epv_credit` is unambiguous: **sum it, never diff it.**

Paired with pannadata PR #54 (chains consumer side). The blog and the chain builder both read `epv_credit ?? equity`, so the rename is transparent.

- Column renamed; **file name (`action_equity.parquet`), step name, and variable names unchanged.**
- `.required_equity_cols` schema check updated to `epv_credit`.

## ⚠️ This PR also carries a pre-existing `dev` commit
`5ff3b81 data-raw/epv: add xG model JSON export for the blog worker` was already on `dev` (not authored here) and is swept into this `dev → main` PR. It's legitimate blog-worker plumbing that needs to reach `main` anyway — flagging it for visibility, not introducing it.

## Test plan
- [x] `parse()` clean
- [x] Verified the 10c slim lookup emits an `epv_credit` column, and pannadata's join produces an `epv_credit` chains column at ~85% coverage (real EPL match).

🤖 Generated with [Claude Code](https://claude.com/claude-code)