### PR TITLE
WC2026: BT knockout-lookup refit + squad-rows export dedupe

### DIFF
--- a/data-raw/match-predictions-opta/11_simulate_wc2026.R
+++ b/data-raw/match-predictions-opta/11_simulate_wc2026.R
@@ -76,8 +76,26 @@ knockout <- build_knockout_lookup(
 # 4. Bradley-Terry ratings — diagnostic only ----
 # No longer used by the simulator; kept as a published team-strength summary
 # (wc2026_team_full_ranks.R consumes wc2026_bt_ratings.parquet).
+#
+# Fit on the FULL 1128-pair knockout lookup, not the 72 group fixtures: with
+# group fixtures only, each team is compared solely against its 3 group
+# rivals, so the comparison graph is 12 disconnected components and
+# cross-group rating levels are optimizer artifacts (a dominant team in a
+# weak group floats to #1 — the "Switzerland tops BT" bug, blog #269). The
+# lookup compares every team with every other team through the same blended
+# match model, making the graph fully connected and the ratings globally
+# comparable. Lookup probs are orientation-averaged; host home_field is
+# baked into pairings involving USA/CAN/MEX, which is intentional — BT now
+# reads as "expected strength at THIS tournament".
 
-bt <- fit_bt_ratings(as.data.frame(wc), neutral = TRUE, verbose = TRUE)
+bt_pairs <- data.frame(
+  home_team = knockout$probs$t1,
+  away_team = knockout$probs$t2,
+  prob_H    = knockout$probs$p_t1,
+  prob_D    = knockout$probs$p_draw,
+  prob_A    = knockout$probs$p_t2
+)
+bt <- fit_bt_ratings(bt_pairs, neutral = TRUE, verbose = TRUE)
 bt_with_groups <- as.data.table(merge(bt$ratings, groups, by = "team"))
 setorder(bt_with_groups, rank)
 arrow::write_parquet(bt_with_groups,

--- a/data-raw/match-predictions-opta/12_export_wc2026_blog.R
+++ b/data-raw/match-predictions-opta/12_export_wc2026_blog.R
@@ -181,6 +181,11 @@ if (!file.exists(squads_path)) {
        " — run announced_squads.R (step 02) first.")
 }
 squads <- as.data.table(read_parquet(squads_path))
+# The announced-squads cache can carry the same player twice (announced +
+# derived source rows). One row per (team, player): keep the highest
+# expected-minutes row.
+setorder(squads, team_name, player_id, -expected_minutes_norm)
+squads <- unique(squads, by = c("team_name", "player_id"))
 
 # Latest-season per-player ratings: same source preference as step 02
 # (skill-based first, raw-stat fallback).

--- a/data-raw/match-predictions-opta/12_export_wc2026_blog.R
+++ b/data-raw/match-predictions-opta/12_export_wc2026_blog.R
@@ -4,11 +4,12 @@
 # pulls wc2026_*.parquet into blog/ and the R2 step ships them to
 # inthegame-data/football/.
 #
-# Produces four parquet files:
+# Produces five parquet files:
 #   wc2026_predictions.parquet    — 72 group-stage match predictions (H/D/A + xG)
 #   wc2026_simulation.parquet     — per-team round + champion probabilities
 #   wc2026_groups.parquet         — per-team group-finish probabilities
 #   wc2026_team_strength.parquet  — per-team strength across rating categories
+#   wc2026_squads.parquet         — per-player squad rows with ratings
 #
 # Inputs (all produced upstream by steps 07 + 11):
 #   07_predictions.rds, 04_match_dataset.rds, wc2026_groups.rds,
@@ -166,6 +167,63 @@ write_parquet(strength, file.path(cache_dir, "wc2026_team_strength.parquet"))
 message(sprintf("  wc2026_team_strength.parquet: %d teams x %d categories",
                 nrow(strength), length(metric_cols) + 2L))
 
+# 5b. Squad rows with player ratings ----
+# One row per squad player: announced/derived squad membership (step 02's
+# announced_squads cache) joined to the latest-season player ratings. Feeds
+# the blog's world-cup-team.qmd squad table. Ratings stay NA when a player
+# has no rated club minutes (smaller leagues) — the blog renders a dash;
+# per [[feedback-no-silent-imputation]] we do NOT zero-fill here (the 0s in
+# step 02 exist for the team aggregator, not for published per-player rows).
+
+squads_path <- file.path(cache_dir, "wc2026_announced_squads.parquet")
+if (!file.exists(squads_path)) {
+  stop("wc2026_announced_squads.parquet not found in ", cache_dir,
+       " — run announced_squads.R (step 02) first.")
+}
+squads <- as.data.table(read_parquet(squads_path))
+
+# Latest-season per-player ratings: same source preference as step 02
+# (skill-based first, raw-stat fallback).
+sq_skill_path <- file.path("data-raw", "cache-skills", "06_seasonal_ratings.rds")
+sq_raw_path   <- file.path("data-raw", "cache-opta", "07_seasonal_ratings.rds")
+sq_seasonal <- if (file.exists(sq_skill_path)) readRDS(sq_skill_path) else readRDS(sq_raw_path)
+
+sq_xrapm <- as.data.table(sq_seasonal$seasonal_xrapm)
+sq_xrapm <- sq_xrapm[order(player_id, -season_end_year), .SD[1L], by = player_id,
+                     .SDcols = intersect(c("xrapm", "offense", "defense", "total_minutes"),
+                                         names(sq_xrapm))]
+setnames(sq_xrapm, "xrapm", "panna", skip_absent = TRUE)
+
+sq_psr <- if (!is.null(sq_seasonal$seasonal_psr) && nrow(sq_seasonal$seasonal_psr) > 0) {
+  p <- as.data.table(sq_seasonal$seasonal_psr)
+  p[order(player_id, -season_end_year), .SD[1L], by = player_id, .SDcols = "psr"]
+} else NULL
+
+sq_epr <- {
+  ep <- file.path(opta_data_dir(), "opta_epr_weekly.parquet")
+  if (file.exists(ep)) {
+    e <- as.data.table(read_parquet(ep))
+    e[, snapshot_date := as.Date(snapshot_date)]
+    e[order(player_id, -snapshot_date), .SD[1L], by = player_id, .SDcols = "epr"]
+  } else NULL
+}
+
+squad_out <- squads[, .(team = team_name, player_id, player_name, position,
+                        expected_minutes_norm, is_starter_pred)]
+squad_out[, group := unname(team_group[team])]
+squad_out <- merge(squad_out, sq_xrapm, by = "player_id", all.x = TRUE)
+if (!is.null(sq_psr)) squad_out <- merge(squad_out, sq_psr, by = "player_id", all.x = TRUE)
+if (!is.null(sq_epr)) squad_out <- merge(squad_out, sq_epr, by = "player_id", all.x = TRUE)
+for (col in c("psr", "epr")) if (!col %in% names(squad_out)) squad_out[[col]] <- NA_real_
+
+setcolorder(squad_out, c("team", "group", "player_id", "player_name", "position",
+                         "expected_minutes_norm", "is_starter_pred",
+                         "panna", "offense", "defense", "epr", "psr", "total_minutes"))
+setorder(squad_out, team, -expected_minutes_norm)
+write_parquet(squad_out, file.path(cache_dir, "wc2026_squads.parquet"))
+message(sprintf("  wc2026_squads.parquet: %d players across %d squads (%d with panna ratings)",
+                nrow(squad_out), uniqueN(squad_out$team), sum(!is.na(squad_out$panna))))
+
 # 6. Save CSV companions for the small published tables ----
 # Per feedback 2026-05-28: small tables (<100KB / <10k rows) get a CSV
 # alongside the parquet for easy human inspection. The parquet remains
@@ -174,7 +232,8 @@ message(sprintf("  wc2026_team_strength.parquet: %d teams x %d categories",
 wc_parquets <- c("wc2026_predictions.parquet",
                  "wc2026_simulation.parquet",
                  "wc2026_groups.parquet",
-                 "wc2026_team_strength.parquet")
+                 "wc2026_team_strength.parquet",
+                 "wc2026_squads.parquet")
 for (p in wc_parquets) {
   pp <- file.path(cache_dir, p)
   cp <- sub("\\.parquet$", ".csv", pp)


### PR DESCRIPTION
Sync dev -> main ahead of the next scheduled predictions run so the cloud
step 11/12 use today's WC2026 changes:

- 99c09de: refit BT on the 1128-pair knockout lookup + export squad rows
- 6e885e1: dedupe (team, player) rows at the squads export

Without this, the auto-triggered cloud run (post-Opta-scrape) publishes
wc2026 blog data from the old export code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)