### PR TITLE
Quiet false-positive pipeline warnings + align elo_k default with production

### DIFF
--- a/R/simulate_world_cup.R
+++ b/R/simulate_world_cup.R
@@ -182,7 +182,8 @@ rank_group_h2h <- function(p, d, f, tbk, m_a, m_b, g_a, g_b) {
 #'   (pairwise knockout probabilities) and `team_elo` (named vector of
 #'   pre-tournament Elo, used as the run-hot baseline).
 #' @param n_sims Integer. Default 10000.
-#' @param elo_k Run-hot Elo K-factor (default 40; 0 disables momentum).
+#' @param elo_k Run-hot Elo K-factor (default 20, matching the production
+#'   pipeline in 11_simulate_wc2026.R; 0 disables momentum).
 #' @param bracket `"fifa2026"` (default) plays the knockouts on the official
 #'   2026 bracket (matches 73-104) with FIFA's third-place slot eligibility;
 #'   `"random"` reshuffles the round of 32 each sim (the pre-2026-06-11
@@ -197,7 +198,7 @@ rank_group_h2h <- function(p, d, f, tbk, m_a, m_b, g_a, g_b) {
 #' @export
 simulate_world_cup <- function(predictions, groups, knockout,
                                 n_sims = 10000L,
-                                elo_k = 40,
+                                elo_k = 20,
                                 bracket = c("fifa2026", "random"),
                                 verbose = TRUE) {
 

--- a/data-raw/match-predictions-opta/01_build_fixture_results.R
+++ b/data-raw/match-predictions-opta/01_build_fixture_results.R
@@ -737,14 +737,19 @@ if (!is.null(fixtures_df)) {
   unresolved_away <- 0L
   if (nrow(team_name_map) > 0) {
     home_lookup <- setNames(team_name_map$team_name, team_name_map$team_id)
+    # Empty-string team_ids are TBD placeholders (e.g. the 32 WC2026 knockout
+    # fixtures, cup finals before semis resolve) — not split-identity risks,
+    # so keep them out of the unresolved counts below.
+    has_home_id <- !is.na(fixtures_clean$home_team_id) & nzchar(fixtures_clean$home_team_id)
+    has_away_id <- !is.na(fixtures_clean$away_team_id) & nzchar(fixtures_clean$away_team_id)
     new_home <- home_lookup[as.character(fixtures_clean$home_team_id)]
     n_home_renamed <- sum(!is.na(new_home) & (is.na(fixtures_clean$home_team) | new_home != fixtures_clean$home_team))
-    unresolved_home <- sum(!is.na(fixtures_clean$home_team_id) & is.na(new_home))
+    unresolved_home <- sum(has_home_id & is.na(new_home))
     fixtures_clean$home_team <- ifelse(is.na(new_home), fixtures_clean$home_team, unname(new_home))
 
     new_away <- home_lookup[as.character(fixtures_clean$away_team_id)]
     n_away_renamed <- sum(!is.na(new_away) & (is.na(fixtures_clean$away_team) | new_away != fixtures_clean$away_team))
-    unresolved_away <- sum(!is.na(fixtures_clean$away_team_id) & is.na(new_away))
+    unresolved_away <- sum(has_away_id & is.na(new_away))
     fixtures_clean$away_team <- ifelse(is.na(new_away), fixtures_clean$away_team, unname(new_away))
   }
 

--- a/data-raw/match-predictions-opta/01_build_fixture_results.R
+++ b/data-raw/match-predictions-opta/01_build_fixture_results.R
@@ -751,6 +751,17 @@ if (!is.null(fixtures_df)) {
     n_away_renamed <- sum(!is.na(new_away) & (is.na(fixtures_clean$away_team) | new_away != fixtures_clean$away_team))
     unresolved_away <- sum(has_away_id & is.na(new_away))
     fixtures_clean$away_team <- ifelse(is.na(new_away), fixtures_clean$away_team, unname(new_away))
+
+    # Info trend line for the excluded population: expected baseline is the
+    # TBD placeholders (64 = 32 WC2026 knockout fixtures x 2 sides while the
+    # tournament is upcoming). A jump here means the scraper started emitting
+    # blank ids for real fixtures — catch it at step 01, not as quietly
+    # degraded predictions at step 07.
+    n_blank_ids <- sum(!has_home_id) + sum(!has_away_id)
+    if (n_blank_ids > 0) {
+      message(sprintf("  %d fixture team-id slots blank (TBD placeholders: WC2026 knockouts, unresolved cup ties)",
+                      n_blank_ids))
+    }
   }
 
   # Always-on diagnostic: distinguishes "rename block ran correctly" from

--- a/man/simulate_world_cup.Rd
+++ b/man/simulate_world_cup.Rd
@@ -9,7 +9,7 @@ simulate_world_cup(
   groups,
   knockout,
   n_sims = 10000L,
-  elo_k = 40,
+  elo_k = 20,
   bracket = c("fifa2026", "random"),
   verbose = TRUE
 )
@@ -29,7 +29,8 @@ pre-tournament Elo, used as the run-hot baseline).}
 
 \item{n_sims}{Integer. Default 10000.}
 
-\item{elo_k}{Run-hot Elo K-factor (default 40; 0 disables momentum).}
+\item{elo_k}{Run-hot Elo K-factor (default 20, matching the production
+pipeline in 11_simulate_wc2026.R; 0 disables momentum).}
 
 \item{bracket}{\code{"fifa2026"} (default) plays the knockouts on the official
 2026 bracket (matches 73-104) with FIFA's third-place slot eligibility;


### PR DESCRIPTION
Follow-up to #83, addressing the residual warnings from the post-merge verification run (27324368999).

## Changes

- **`01_build_fixture_results.R`**: the "64 fixture team_ids have no lineup match" warning was counting the 32 WC2026 knockout fixtures twice (home + away) — their TBD placeholder team_ids are **empty strings**, which pass the `!is.na()` check. Blank ids are now excluded from the unresolved count; the warning goes back to flagging only genuine split-identity risks (newly-promoted teams with no played matches).
- **`simulate_world_cup()`**: `elo_k` default 40 → 20, matching the value the production pipeline (`11_simulate_wc2026.R`) has always passed explicitly. Neither value was empirically tuned; this just makes one number canonical. **Zero behavior change in production.** Roxygen/Rd updated to note the default matches the pipeline.

## Not in this PR (upstream)

The "366 matches still using events fallback" warning is a real pannadata bug — the daily scrape's `recent=1` flipped to the 2026-27 season at the April calendar publish and abandoned the 2025-26 run-in, freezing those fixture rows at `status = "Fixture"`. Tracked in peteowen1/pannadata#60; a targeted backfill scrape for the 10 affected leagues is running.

## Validation

- simulate_world_cup test suite: 5,087 assertions pass, 0 warnings.
- `01_build_fixture_results.R` parse-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)