### PR TITLE
Gate doomed cloud RAPM trigger + xmetrics for new leagues

### DIFF
--- a/.github/workflows/opta-pipeline.yml
+++ b/.github/workflows/opta-pipeline.yml
@@ -19,8 +19,13 @@ on:
         description: 'Start from step N (1-9). Downloads intermediate caches from predictions-cache release. Default 1 = full run.'
         type: number
         required: false
-  repository_dispatch:
-    types: [opta-scrape-complete]
+  # repository_dispatch trigger removed 2026-06-11 (panna#87): the pipeline
+  # OOMs the 16GB hosted runner deterministically since the 4-league
+  # expansion, so the daily opta-scrape-complete dispatch burned ~1-3
+  # runner-hours per day on guaranteed failures. Manual-only until the
+  # memory profile fits 16GB again (or the job moves to a larger runner).
+  # repository_dispatch:
+  #   types: [opta-scrape-complete]
 
 env:
   GITHUB_PAT: ${{ secrets.WORKFLOW_PAT }}

--- a/data-raw/epv/03_calculate_player_xmetrics.R
+++ b/data-raw/epv/03_calculate_player_xmetrics.R
@@ -20,11 +20,17 @@ devtools::load_all()
 
 # 1. Configuration ----
 
-LEAGUES <- c(
+# Config override pattern: debug/test scripts can set LEAGUES before sourcing
+# (e.g. to score only newly-added leagues against existing SPADL caches).
+if (!exists("LEAGUES", inherits = FALSE)) LEAGUES <- c(
   # Big 5
   "ENG", "ESP", "GER", "ITA", "FRA",
   # Extended domestic
   "NED", "POR", "TUR", "ENG2", "SCO",
+  # Americas / Asia domestic (added 2026-06-11; events backfilled to 2013-14)
+  "MLS", "MEX", "ARG", "SAU",
+  # Club-comp bridges (cross-league connectivity for offsets)
+  "LIB", "SUD", "CCC", "LGC", "ACLE", "CWC",
   # European comps
   "UCL", "UEL", "UECL",
   # International


### PR DESCRIPTION
Two small changes:

- **Disable `opta-pipeline.yml`'s `repository_dispatch` trigger** (panna#87): since the 4-league expansion the pipeline OOMs the 16GB hosted runner deterministically (3/3 failures, [MEM] tracer shows the 15.8GB ceiling each time), so the daily scrape-complete dispatch burned 1–3 runner-hours/day on guaranteed failures. Manual-only until the memory profile fits or the job moves to a 32GB runner. Workflows trigger from main, so this needs the merge to take effect before tomorrow's 5AM scrape.
- **Add the 10 new comps to xmetrics scoring** (`03_calculate_player_xmetrics.R`): MLS/MEX/ARG/SAU + the six club bridges, with the `if (!exists())` override pattern. Local scoring run in progress; closes the new leagues' SPM coverage gap at the root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)