### PR TITLE
SPM season-match fix + new leagues in game-logs export + xmetrics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,7 +154,7 @@ Stat ratings → PSR/OSR/DSR (smoothed skills via glmnet) ───────�
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
 | `R-CMD-check.yaml` | Push to `dev`, PRs to `main` | Package checks |
-| `opta-pipeline.yml` | Manual dispatch | Opta RAPM/SPM on GHA, auto-uploads caches |
+| `opta-pipeline.yml` | Manual dispatch | Opta RAPM/SPM on GHA, auto-uploads caches. ⚠ OOMs the 16GB hosted runner since the 2026-06 4-league expansion (panna#87) — run the pipeline locally (needs ~25GB+ RAM) until fixed; the scrape-complete auto-trigger was removed for this reason |
 | `pkgdown.yaml` | Push | Documentation site |
 | `predictions-pipeline.yml` | Wed 8 AM UTC / manual / `opta-scrape-complete` dispatch | Weekly match predictions. Runs steps 1-10c + 11 (WC2026 sim) + 12 (WC2026 blog export). Triggers `predictions-complete` repository_dispatch on `pannadata` to refresh blog data. Note: WC2026 sim defaults to FALSE in `run_predictions_opta.R` but the workflow enables it in its `run_steps` override. |
 | `psr-weekly-snapshot.yml` | Weekly snapshot / manual | PSR weekly snapshot generation |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,7 @@ Stat ratings → PSR/OSR/DSR (smoothed skills via glmnet) ───────�
 - **Player IDs**: Opta pipeline uses real alphanumeric Opta IDs (e.g., `5ilkkfbsss0bxd6ttdlqg0uz9`) throughout. FBref uses FBref player IDs.
 - **Config override pattern**: `run_pipeline_opta.R` uses `if (!exists(...))` so test scripts can set variables before sourcing.
 - **Tournament seasons**: Use "YYYY Country" format (e.g., "2018 Russia"), not "YYYY-YYYY".
+- **Season subsetting: ALWAYS select by `extract_season_end_year()`, never by exact `"YYYY-YYYY"` string match.** Three label formats share one end year: "2025-2026" (European), "2026" (calendar-year leagues — MLS/Argentina/Brazil), "2026 Canada-Mexico-USA" (tournaments). The exact-match-then-fallback-if-empty pattern is a trap: the European labels always match, so the fallback never fires and calendar-league rows are silently dropped. This exact bug excluded MLS/ARG/BRA from every season's SPM build until 2026-06-12 (`07_seasonal_ratings.R`, the blog's 25% missing-SPM gap).
 - **Position taxonomy**: Prefer the 16-role classification (GK/CB/LB/RB/LWB/RWB/DM/CM/LM/RM/CAM/LW/RW/CF/LF/RF) over the legacy 4-bucket GK/DEF/MID/FWD when adding features, aggregations, or display labels. Canonical mapper: `classify_role(position, position_side)` in `R/minutes_model.R`. Empirical 10+ min spread between roles inside the same broad bucket (e.g. CB averages 87 min, LB 86, AM 80, ST-Right 77). Refactor old broad-bucket usage opportunistically.
 
 ## Gotchas

--- a/data-raw/match-predictions-opta/10b_export_game_logs.R
+++ b/data-raw/match-predictions-opta/10b_export_game_logs.R
@@ -29,10 +29,23 @@ tag <- "blog-latest"
 #   (3) intl_tournament — WC / EURO use "YYYY Country"; map a summer
 #                         tournament to the domestic season ending that year.
 domestic_leagues  <- c("ENG", "ESP", "GER", "ITA", "FRA",
-                        "NED", "POR", "SCO", "TUR", "ENG2")
+                        "NED", "POR", "SCO", "TUR", "ENG2",
+                        "MEX", "SAU")          # added 2026-06-11 ("YYYY-YYYY" labels)
+# Calendar-year season labels ("2026" not "2025-2026") — resolved through the
+# same year-prefix matching as the intl tournaments ("2025-2026" -> "2026").
+calendar_leagues  <- c("MLS", "ARG")
 continental_cups  <- c("UCL", "UEL", "UECL")
 intl_tournaments  <- c("WC", "EURO")
-blog_leagues      <- c(domestic_leagues, continental_cups, intl_tournaments)
+# Leagues whose season label is resolved by year prefix rather than passed through
+season_label_leagues <- c(intl_tournaments, calendar_leagues)
+# Override guard: backfill runs can process a league subset. CAUTION — the
+# per-season output parquet contains ONLY the processed leagues, so a subset
+# run must set upload_game_logs <- FALSE and merge into the existing
+# game_logs_<season>.parquet files instead of clobbering them.
+if (!exists("blog_leagues", inherits = FALSE)) {
+  blog_leagues    <- c(domestic_leagues, calendar_leagues,
+                       continental_cups, intl_tournaments)
+}
 
 # Seasons to export. Vector (new) or scalar `game_log_season` (back-compat).
 if (!exists("game_log_seasons", inherits = FALSE)) {
@@ -237,7 +250,7 @@ validate_game_log_schema <- function(dt, league, season) {
   # matches vs its played fixtures. warn_threshold is the noisy-but-OK band.
   ls_pairs <- lapply(blog_leagues, function(lg) {
     lg_season <- resolve_league_season(lg, season,
-                                         tournament_leagues = intl_tournaments)
+                                         tournament_leagues = season_label_leagues)
     if (is.null(lg_season)) return(NULL)
     list(league = lg, season = lg_season)
   })
@@ -292,7 +305,7 @@ validate_game_log_schema <- function(dt, league, season) {
   for (league in blog_leagues) {
     tryCatch({
       league_season <- resolve_league_season(league, season,
-                                               tournament_leagues = intl_tournaments)
+                                               tournament_leagues = season_label_leagues)
       if (is.null(league_season)) {
         message(sprintf("\n  Skipping %s %s — no tournament this year", league, season))
         stop(skip_league_cond("no tournament this year"))

--- a/data-raw/player-ratings-opta/07_seasonal_ratings.R
+++ b/data-raw/player-ratings-opta/07_seasonal_ratings.R
@@ -93,20 +93,20 @@ fit_season_ratings_opta <- function(splint_data, opta_stats, season,
   # Filter Opta stats to this season
   # Handle both standard ("2024-2025") and tournament ("2018 Russia") season formats
   season_str <- paste0(season - 1, "-", season)
-  season_opta_stats <- opta_stats[opta_stats$season == season_str, ]
-
-  # If no match with standard format, try matching by extracted end year
-  if (nrow(season_opta_stats) == 0) {
-    end_years <- sapply(unique(opta_stats$season), extract_season_end_year)
-    matching_seasons <- names(end_years)[end_years == season]
-    if (length(matching_seasons) > 1) {
-      cat(sprintf("  Note: %d seasons match end year %d: %s\n",
-                  length(matching_seasons), season, paste(matching_seasons, collapse = ", ")))
-    }
-    if (length(matching_seasons) > 0) {
-      season_opta_stats <- opta_stats[opta_stats$season %in% matching_seasons, ]
-    }
+  # Select by extracted end year, not exact "YYYY-YYYY" match: calendar-year
+  # leagues (MLS/Argentina/Brazil, label "2026") and tournaments ("2026
+  # Canada-Mexico-USA") share an end year with the European "2025-2026"
+  # season. The old exact-match-then-fallback logic only reached the
+  # fallback when the standard format matched NOTHING — so calendar-league
+  # stats were silently excluded from every season's SPM build (the blog's
+  # 25% missing-SPM gap, found 2026-06-12).
+  end_years <- sapply(unique(opta_stats$season), extract_season_end_year)
+  matching_seasons <- names(end_years)[end_years == season]
+  if (length(matching_seasons) > 1) {
+    cat(sprintf("  Note: %d seasons match end year %d: %s\n",
+                length(matching_seasons), season, paste(matching_seasons, collapse = ", ")))
   }
+  season_opta_stats <- opta_stats[opta_stats$season %in% matching_seasons, ]
 
   cat(sprintf("  Season Opta stats rows: %d\n", nrow(season_opta_stats)))
 
@@ -125,15 +125,11 @@ fit_season_ratings_opta <- function(splint_data, opta_stats, season,
 
   # Enrich with xMetrics if available (SPM models may require these features)
   if (!is.null(opta_xmetrics) && nrow(opta_xmetrics) > 0) {
-    season_xm <- opta_xmetrics[opta_xmetrics$season == season_str, ]
-    # Fallback: match by extracted end year for tournament formats
-    if (nrow(season_xm) == 0) {
-      xm_end_years <- sapply(unique(opta_xmetrics$season), extract_season_end_year)
-      xm_matching <- names(xm_end_years)[xm_end_years == season]
-      if (length(xm_matching) > 0) {
-        season_xm <- opta_xmetrics[opta_xmetrics$season %in% xm_matching, ]
-      }
-    }
+    # End-year matching for the same reason as the stats subset above —
+    # calendar-year league labels never equal the "YYYY-YYYY" season_str.
+    xm_end_years <- sapply(unique(opta_xmetrics$season), extract_season_end_year)
+    xm_matching <- names(xm_end_years)[xm_end_years == season]
+    season_xm <- opta_xmetrics[opta_xmetrics$season %in% xm_matching, ]
     if (nrow(season_xm) > 0) {
       xm_agg <- season_xm %>%
         group_by(player_id) %>%


### PR DESCRIPTION
Overnight batch (2026-06-12). **Time-sensitive**: main's predictions pipeline (daily scrape-complete dispatch + Wednesday cron) runs step 10b — without this merge it rebuilds `game_logs_2025-2026.parquet` from the OLD league list and clobbers the new-league rows merged to blog-latest tonight.

- **`07_seasonal_ratings.R` season-match fix**: per-season stats (and xmetrics) were selected by exact "YYYY-YYYY" match with an end-year fallback that only fired on zero matches — calendar-year league labels ("2026": MLS/Argentina/Brazil) never reached it, so those players were **excluded from every season's SPM build**. Root cause of the blog's 25% missing-SPM gap; verified fixed: 2026 missing-SPM 24.9% → **3.0%**. Both subsets now select by `extract_season_end_year()`. (Gotcha added to CLAUDE.md; the only other instances of the pattern are deprecated FBref code.)
- **10b game-logs export gains MLS/MEX/ARG/SAU**: MEX/SAU as standard domestic; MLS/ARG via the year-prefix season resolution that already serves WC/EURO. `blog_leagues` gains an `exists()` override for subset backfills (documented no-upload + merge caveat). 13-season backfill done locally (~432K rows merged to blog-latest).
- **xmetrics scoring covers the 10 new comps** (`03_calculate_player_xmetrics.R`); 236K-row consolidated parquet on opta-latest.
- Docs: season-subsetting gotcha, opta-pipeline OOM constraint note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)