### PR TITLE
xGOT review fixes + EPV pipeline robustness [dev→main]

### DIFF
--- a/.github/workflows/epv-pipeline.yml
+++ b/.github/workflows/epv-pipeline.yml
@@ -152,6 +152,25 @@ jobs:
             source('data-raw/epv/01_train_epv_models.R')
           "
 
+      - name: Upload models (immediately after training)
+        # Publish the freshly-trained models right after training so a slow or
+        # cancelled xMetrics step (below) can never skip publishing — that
+        # fragility left xgot_model unpublished on 2026-06-16. The final
+        # "Upload trained models" step re-uploads (--clobber, idempotent) and
+        # handles the WP model.
+        if: ${{ env.WP_ONLY != 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
+        run: |
+          set -euo pipefail
+          CACHE_DIR="data-raw/cache/epv"
+          for f in xg_model.rds xgot_model.rds xpass_model.rds epv_model.rds; do
+            if [ -f "$CACHE_DIR/$f" ]; then
+              gh release upload models "$CACHE_DIR/$f" --repo peteowen1/pannadata --clobber \
+                && echo "  Uploaded $f (early)"
+            fi
+          done
+
       - name: Calculate player xMetrics
         if: ${{ env.EXPORT_XMETRICS == 'true' }}
         env:

--- a/R/xg_model.R
+++ b/R/xg_model.R
@@ -720,12 +720,17 @@ aggregate_player_xmetrics <- function(spadl, lineups, min_minutes = 0) {
     if (all(c("xgot", "shot_on_target") %in% names(shots_dt))) {
       np <- shots_dt[is.na(is_penalty) | is_penalty == 0L]
       xgot_agg <- np[, .(
+        n_xgot_shots = sum(!is.na(xgot)),   # shots with a defined xGOT (off-target 0s count; missing-coord NAs don't)
         xgot = sum(xgot, na.rm = TRUE),
         placement_added = sum(xgot - xg, na.rm = TRUE),
         xgot_placement = sum(data.table::fifelse(
           shot_on_target %in% TRUE, xgot - xg, 0), na.rm = TRUE)
       ), by = .(player_id, player_name, team_id)]
       xgot_agg[, targeting := placement_added - xgot_placement]
+      # No usable xGOT signal (all non-pen shots missing coords) -> the na.rm
+      # sums collapse to a fake 0; surface as NA, never impute (CLAUDE.md rule).
+      xgot_agg[n_xgot_shots == 0L,
+               c("xgot", "placement_added", "xgot_placement", "targeting") := NA_real_]
       shooting <- xgot_agg[shooting, on = c("player_id", "player_name", "team_id")]
     }
   } else {
@@ -784,11 +789,15 @@ aggregate_player_xmetrics <- function(spadl, lineups, min_minutes = 0) {
   if (length(i_cols) > 0) result[, (i_cols) := NULL]
 
   # Fill NAs with 0
+  # NOTE: the xGOT decomposition columns (xgot/placement_added/xgot_placement/
+  # targeting) are deliberately NOT in this NA->0 fill — for them a 0 is a
+  # meaningful value ("placed exactly at xG"), so a player with no xGOT data
+  # must stay NA, not be imputed to 0 (CLAUDE.md no-silent-impute rule). Only
+  # the coverage count n_xgot_shots is filled (0 = genuinely no such shots).
   num_cols <- c("shots", "shots_on_target", "goals", "penalty_goals", "npgoals",
                 "xg", "npxg", "key_passes", "assists", "xa",
                 "passes_attempted", "passes_completed", "sum_xpass",
-                "xpass_overperformance", "xpass_avg",
-                "xgot", "placement_added", "xgot_placement", "targeting")
+                "xpass_overperformance", "xpass_avg", "n_xgot_shots")
   for (col in num_cols) {
     if (col %in% names(result)) {
       data.table::set(result, which(is.na(result[[col]])), col, 0)

--- a/R/xgot_model.R
+++ b/R/xgot_model.R
@@ -44,7 +44,7 @@ XGOT_ON_TARGET_TYPE_IDS <- c(15L, 16L)
 #' feature(s) the xGOT model learns from. This is the heart of the model: how
 #' you encode "where in the frame" decides what the tree can discover.
 #'
-#' The empirical signal from EPL 2024-25 on-target shots (your data):
+#' The empirical signal from EPL 2024-25 on-target shots (illustrative):
 #'   distance to nearest post:  hug-post(<1)=0.358  near=0.248  mid=0.106  central=0.069
 #'   height band:               low(<5)=0.386  mid(5-12)=0.284  high(12-20)=0.056  top(>20)=0.287
 #' Note the height effect is U-SHAPED (mid-height = keeper's easy reach = worst;
@@ -150,7 +150,7 @@ prepare_shots_for_xgot <- function(shot_events,
     bodypart = bodypart, situation = situation, is_big_chance = big_chance
   )
 
-  # Placement features (your contribution).
+  # Placement features.
   placement <- .create_placement_features(shot_events$goalmouth_y, shot_events$goalmouth_z)
   features <- cbind(features, placement)
 
@@ -296,9 +296,10 @@ predict_xgot <- function(xgot_model, shot_features) {
 #' @param xgot_model Fitted xGOT model.
 #' @param goalmouth_lookup Data frame keyed by (\code{match_id},
 #'   \code{event_id}) with \code{type_id}, \code{goalmouth_y},
-#'   \code{goalmouth_z} for shot events - e.g. from match_events /
-#'   opta_shot_events. (Opta q102/103 live in match_events qualifier_json, so
-#'   no backfill is needed to build this on the inference path.)
+#'   \code{goalmouth_z}, and \code{situation} for shot events - e.g. from
+#'   match_events / opta_shot_events. \code{situation} is required to avoid
+#'   train/serve skew (the model trained on real situations); without it,
+#'   set-piece/corner/free-kick shots are scored as open-play.
 #' @return SPADL actions with an \code{xgot} column added.
 #' @keywords internal
 add_xgot_to_spadl <- function(spadl_actions, xgot_model, goalmouth_lookup) {
@@ -319,16 +320,31 @@ add_xgot_to_spadl <- function(spadl_actions, xgot_model, goalmouth_lookup) {
     event_id = shots$original_event_id,
     stringsAsFactors = FALSE
   )
-  lk <- goalmouth_lookup[, c("match_id", "event_id", "type_id",
-                             "goalmouth_y", "goalmouth_z")]
+  # `situation` is needed to match training features (open/set-piece/corner/
+  # free-kick); warn loudly if absent rather than silently skew predictions.
+  have_situation <- "situation" %in% names(goalmouth_lookup)
+  if (!have_situation) {
+    cli::cli_warn("goalmouth_lookup lacks `situation` - set-piece shots will be scored as open-play (train/serve skew).")
+  }
+  lk_cols <- c("match_id", "event_id", "type_id", "goalmouth_y", "goalmouth_z",
+               if (have_situation) "situation")
+  lk <- goalmouth_lookup[, lk_cols, drop = FALSE]
+  # De-dup on the join key: a duplicated (match_id, event_id) would let merge()
+  # inflate rows and misalign coords to the wrong shot (silent wrong xGOT).
+  lk <- lk[!duplicated(lk[, c("match_id", "event_id")]), , drop = FALSE]
+
   joined <- merge(key, lk, by = c("match_id", "event_id"),
                   all.x = TRUE, sort = FALSE)
   # merge() may reorder; realign to shots order via a stable key match.
   ord <- match(paste(key$match_id, key$event_id),
                paste(joined$match_id, joined$event_id))
   joined <- joined[ord, ]
+  stopifnot(nrow(joined) == nrow(key))   # 1:1 invariant (guaranteed by de-dup)
 
-  on_target <- joined$type_id %in% XGOT_ON_TARGET_TYPE_IDS
+  # NA-preserving: `%in%` collapses a missing type_id (unmatched shot) to
+  # FALSE, which would mislabel it off-target (xgot=0) instead of unknown (NA).
+  on_target <- ifelse(is.na(joined$type_id), NA,
+                      joined$type_id %in% XGOT_ON_TARGET_TYPE_IDS)
   has_gm <- !is.na(joined$goalmouth_y) & !is.na(joined$goalmouth_z)
   predable <- on_target & has_gm
   predable[is.na(predable)] <- FALSE
@@ -339,20 +355,29 @@ add_xgot_to_spadl <- function(spadl_actions, xgot_model, goalmouth_lookup) {
   if (any(predable)) {
     is_big_chance <- if ("is_big_chance" %in% names(shots)) as.integer(shots$is_big_chance[predable]) else 0L
     bodypart <- if ("bodypart" %in% names(shots)) shots$bodypart[predable] else NULL
+    # Real situation (not NULL) so set-piece/corner/FK shots match training.
+    situation <- if (have_situation) joined$situation[predable] else NULL
     base <- .create_shot_features(
       x = shots$start_x[predable], y = shots$start_y[predable],
-      bodypart = bodypart, situation = NULL, is_big_chance = is_big_chance
+      bodypart = bodypart, situation = situation, is_big_chance = is_big_chance
     )
     plc <- .create_placement_features(joined$goalmouth_y[predable], joined$goalmouth_z[predable])
     xgot_vec[predable] <- predict_xgot(xgot_model, cbind(base, plc))
   }
+
+  # Own-goal guard: an own goal is logged type 16 at the scorer's own end
+  # (start_x < 50). Its goal-mouth placement is meaningless for the shooter ->
+  # NA, mirroring enrich_shots_xgot.R + the own-goal xG convention (CLAUDE.md).
+  is_og <- joined$type_id == 16L & !is.na(shots$start_x) & shots$start_x < 50
+  is_og[is.na(is_og)] <- FALSE
+  xgot_vec[is_og] <- NA_real_
 
   spadl_actions$xgot[shot_idx] <- xgot_vec
   spadl_actions$shot_on_target[shot_idx] <- on_target  # TRUE/FALSE/NA per raw type_id
   n_pred <- sum(predable)
   n_na_ot <- sum(on_target & !has_gm, na.rm = TRUE)
   cli::cli_alert_success(
-    "Added xGOT to {length(shot_idx)} shots ({n_pred} on-target scored, {n_na_ot} on-target missing coords -> NA, rest off-target -> 0)"
+    "Added xGOT to {length(shot_idx)} shots ({n_pred} scored, {n_na_ot} on-target no-coords -> NA, {sum(is_og)} own-goal -> NA, rest off-target -> 0)"
   )
   spadl_actions
 }

--- a/data-raw/epv/01_train_epv_models.R
+++ b/data-raw/epv/01_train_epv_models.R
@@ -109,7 +109,9 @@ if (length(LEAGUES) == 0L) {
   cli_abort(c("No leagues with local data in the season window (end year >= {MIN_SEASON_END_YEAR}).",
               "i" = "Check the Download Opta event data step populated data/opta/."))
 }
-cli_alert_info("Discovered {length(LEAGUES)} leagues, {sum(lengths(league_seasons))} league-seasons (end year >= {MIN_SEASON_END_YEAR})")
+n_total <- sum(lengths(league_seasons))
+t_load_start <- Sys.time()
+cli_alert_info("Discovered {length(LEAGUES)} leagues, {n_total} league-seasons (end year >= {MIN_SEASON_END_YEAR})")
 
 for (league in LEAGUES) {
   for (season in league_seasons[[league]]) {
@@ -154,7 +156,10 @@ for (league in LEAGUES) {
       total_chains <- total_chains + nrow(outcomes_chunk)
       loaded_leagues <- union(loaded_leagues, league)
 
-      cli_alert_success("  {key}: {format(nrow(events), big.mark=',')} events -> {format(nrow(labeled_chunk), big.mark=',')} labeled actions, {format(nrow(outcomes_chunk), big.mark=',')} chains -> {basename(chunk_path)}")
+      # Progress + live ETA so a long run is legible in the (browser) log.
+      el_min <- as.numeric(difftime(Sys.time(), t_load_start, units = "mins"))
+      eta_min <- if (iter_count > 0) el_min / iter_count * (n_total - iter_count) else NA_real_
+      cli_alert_success("  [{iter_count}/{n_total}] {key}: {format(nrow(events), big.mark=',')} events -> {format(nrow(labeled_chunk), big.mark=',')} actions ({round(el_min, 1)}m in, ~{round(eta_min, 1)}m left)")
 
       rm(labeled_chunk, outcomes_chunk, events, shot_events, lineups)
       # Full gc every 5 iterations to bound long-running heap creep
@@ -174,6 +179,7 @@ n_leagues_loaded <- length(loaded_leagues)
 rm(all_shots, all_lineups); gc(verbose = FALSE, full = TRUE)
 
 n_chunks <- length(list.files(LABELED_CHUNKS_DIR, pattern = "^chunk_.*\\.parquet$"))
+cli_alert_success("Load+chain phase: {n_chunks} chunks in {round(as.numeric(difftime(Sys.time(), t_load_start, units='mins')), 1)} min ({length(failed_keys)}/{iter_count} failed)")
 cli_alert_success("Total: {format(total_events, big.mark=',')} events -> {format(total_actions, big.mark=',')} labeled actions, {format(total_chains, big.mark=',')} chains from {n_leagues_loaded} leagues across {n_chunks} chunks")
 
 # Loud failure if no chunks were produced — every (league, season) skipped.
@@ -289,14 +295,14 @@ cli_alert_success("Sampled — epv: {format(nrow(epv_features), big.mark=',')} r
 # 5. Train xG Model ----
 
 cli_h2("Step 4: Train xG Model")
-
+t0 <- Sys.time()
 shot_features <- prepare_shots_for_xg(shots)
 xg_model <- fit_xg_model(shot_features,
                           nrounds = XGB_PARAMS$nrounds,
                           early_stopping_rounds = XGB_PARAMS$early_stopping_rounds,
                           verbose = XGB_PARAMS$verbose)
 
-cli_alert_success("xG Model: best iter={xg_model$best_nrounds}, logloss={round(xg_model$best_logloss, 4)}")
+cli_alert_success("xG Model: best iter={xg_model$best_nrounds}, logloss={round(xg_model$best_logloss, 4)} [{round(as.numeric(difftime(Sys.time(), t0, units='mins')), 1)}m]")
 saveRDS(xg_model, file.path(CACHE_DIR, "xg_model.rds"))
 
 # 5b. Train xGOT (post-shot xG) Model ----
@@ -305,12 +311,13 @@ saveRDS(xg_model, file.path(CACHE_DIR, "xg_model.rds"))
 # skip cleanly otherwise so the xG/xPass/EPV pipeline is never blocked.
 cli_h2("Step 4b: Train xGOT Model")
 if (all(c("goalmouth_y", "goalmouth_z") %in% names(shots))) {
+  t0 <- Sys.time()
   xgot_features <- prepare_shots_for_xgot(shots)
   xgot_model <- fit_xgot_model(xgot_features,
                                nrounds = XGB_PARAMS$nrounds,
                                early_stopping_rounds = XGB_PARAMS$early_stopping_rounds,
                                verbose = XGB_PARAMS$verbose)
-  cli_alert_success("xGOT Model: best iter={xgot_model$best_nrounds}, logloss={round(xgot_model$best_logloss, 4)}")
+  cli_alert_success("xGOT Model: best iter={xgot_model$best_nrounds}, logloss={round(xgot_model$best_logloss, 4)} [{round(as.numeric(difftime(Sys.time(), t0, units='mins')), 1)}m]")
   saveRDS(xgot_model, file.path(CACHE_DIR, "xgot_model.rds"))
 } else {
   xgot_model <- NULL
@@ -320,7 +327,7 @@ if (all(c("goalmouth_y", "goalmouth_z") %in% names(shots))) {
 # 6. Train xPass Model ----
 
 cli_h2("Step 5: Train xPass Model")
-
+t0 <- Sys.time()
 # pass_features was generated and sampled per-chunk in Step 2 to bound peak
 # memory. Subsampling here would be redundant.
 xpass_model <- fit_xpass_model(pass_features,
@@ -328,13 +335,13 @@ xpass_model <- fit_xpass_model(pass_features,
                                 early_stopping_rounds = XGB_PARAMS$early_stopping_rounds,
                                 verbose = XGB_PARAMS$verbose)
 
-cli_alert_success("xPass Model: best iter={xpass_model$best_nrounds}, logloss={round(xpass_model$best_logloss, 4)}")
+cli_alert_success("xPass Model: best iter={xpass_model$best_nrounds}, logloss={round(xpass_model$best_logloss, 4)} [{round(as.numeric(difftime(Sys.time(), t0, units='mins')), 1)}m]")
 saveRDS(xpass_model, file.path(CACHE_DIR, "xpass_model.rds"))
 
 # 7. Train EPV Model (simple features with league) ----
 
 cli_h2("Step 6: Train EPV Model (simple features)")
-
+t0 <- Sys.time()
 # epv_features and spadl_labeled were generated and aligned-sampled per-chunk
 # in Step 2 to bound peak memory. Subsampling here would be redundant.
 epv_model <- fit_epv_model(epv_features, spadl_labeled,
@@ -347,7 +354,7 @@ epv_model <- fit_epv_model(epv_features, spadl_labeled,
 epv_model$panna_metadata$feature_mode <- "simple"
 
 metric_name <- if (EPV_METHOD == "goal") "mlogloss" else "rmse"
-cli_alert_success("EPV Model: best iter={epv_model$best_nrounds}, {metric_name}={round(epv_model$best_metric, 4)}")
+cli_alert_success("EPV Model: best iter={epv_model$best_nrounds}, {metric_name}={round(epv_model$best_metric, 4)} [{round(as.numeric(difftime(Sys.time(), t0, units='mins')), 1)}m]")
 cli_alert_info("  Trained on {n_leagues_loaded} leagues, {format(epv_model$panna_metadata$n_actions, big.mark=',')} actions")
 # Save with method suffix (epv_model_goal.rds or epv_model_xg.rds)
 epv_method_file <- paste0("epv_model_", EPV_METHOD, ".rds")

--- a/data-raw/epv/03_calculate_player_xmetrics.R
+++ b/data-raw/epv/03_calculate_player_xmetrics.R
@@ -70,9 +70,14 @@ for (league in LEAGUES) {
   opta_league <- to_opta_league(league)
   seasons <- tryCatch(list_opta_seasons(league), error = function(e) character(0))
   if (length(seasons) > 0) {
-    # Filter to START_SEASON onwards (works for both "2024-2025" and "2018 Russia" formats)
+    # Filter to START_SEASON onwards by END YEAR — never a lexical string
+    # compare: calendar/tournament labels ("2026", "2018 Russia") sort wrong
+    # against "2013-2014" and silently drop valid seasons (panna/CLAUDE.md
+    # "Season subsetting"; 01_train uses the same extract_season_end_year path).
     if (exists("START_SEASON") && !is.null(START_SEASON)) {
-      seasons <- seasons[seasons >= START_SEASON]
+      floor_yr <- extract_season_end_year(START_SEASON)
+      ey <- vapply(seasons, extract_season_end_year, numeric(1))
+      seasons <- seasons[!is.na(ey) & ey >= floor_yr]
     }
     if (length(seasons) > 0) {
       league_seasons[[league]] <- seasons
@@ -150,15 +155,24 @@ for (league in names(league_seasons)) {
       # original_event_id inside add_xgot_to_spadl. Skips cleanly if the model
       # or the goalmouth columns aren't available yet.
       if (!is.null(xgot_model)) {
+        # Distinguish a genuine load error (warn with the cause) from coords
+        # being legitimately absent — don't report a corrupt parquet as
+        # "missing coords".
         shot_ev <- tryCatch(
           load_opta_shot_events(league, season = season, source = "local"),
-          error = function(e) NULL
+          error = function(e) {
+            cli_alert_warning("  xGOT: shot_events failed to load for {label}: {e$message}")
+            NULL
+          }
         )
-        gm_cols <- c("match_id", "event_id", "type_id", "goalmouth_y", "goalmouth_z")
-        if (!is.null(shot_ev) && all(gm_cols %in% names(shot_ev))) {
+        req_cols <- c("match_id", "event_id", "type_id", "goalmouth_y", "goalmouth_z")
+        if (!is.null(shot_ev) && all(req_cols %in% names(shot_ev))) {
+          # Pass `situation` too (when present) — add_xgot_to_spadl needs it to
+          # match training features and avoid set-piece train/serve skew.
+          lk_cols <- c(req_cols, intersect("situation", names(shot_ev)))
           spadl <- add_xgot_to_spadl(spadl, xgot_model,
-                                     as.data.frame(shot_ev)[, gm_cols])
-        } else {
+                                     as.data.frame(shot_ev)[, lk_cols])
+        } else if (!is.null(shot_ev)) {
           cli_alert_warning("  Skipping xGOT for {label}: shot_events lack goalmouth coords (run backfill + re-upload)")
         }
       }

--- a/man/add_xgot_to_spadl.Rd
+++ b/man/add_xgot_to_spadl.Rd
@@ -14,16 +14,17 @@ add_xgot_to_spadl(spadl_actions, xgot_model, goalmouth_lookup)
 
 \item{goalmouth_lookup}{Data frame keyed by (\code{match_id},
 \code{event_id}) with \code{type_id}, \code{goalmouth_y},
-\code{goalmouth_z} for shot events — e.g. from match_events /
-opta_shot_events. (Opta q102/103 live in match_events qualifier_json, so
-no backfill is needed to build this on the inference path.)}
+\code{goalmouth_z}, and \code{situation} for shot events - e.g. from
+match_events / opta_shot_events. \code{situation} is required to avoid
+train/serve skew (the model trained on real situations); without it,
+set-piece/corner/free-kick shots are scored as open-play.}
 }
 \value{
 SPADL actions with an \code{xgot} column added.
 }
 \description{
 Adds post-shot xG to shot actions. xGOT is defined only for ON-TARGET
-shots, so this needs the goal-mouth crossing point, which SPADL drops —
+shots, so this needs the goal-mouth crossing point, which SPADL drops -
 it is joined back from \code{goalmouth_lookup} via the preserved
 \code{original_event_id}. Assignment:
 on-target + coords    -> model prediction

--- a/tests/testthat/test-xgot-model.R
+++ b/tests/testthat/test-xgot-model.R
@@ -55,3 +55,63 @@ test_that("aggregate_player_xmetrics emits a consistent finishing decomposition"
   expect_equal(r$targeting, -0.1)               # off-target miss: 0 - 0.1
   expect_equal(r$placement_added, r$xgot_placement + r$targeting)
 })
+
+test_that("aggregate_player_xmetrics excludes penalties from the xGOT decomposition", {
+  spadl <- data.frame(
+    match_id = "m1", player_id = "A", player_name = "Pl A", team_id = "T",
+    action_type = "shot",
+    result = c("success", "success"),
+    opta_type_id = c(16L, 16L),                 # both goals
+    xg   = c(0.2, 0.76), xgot = c(0.7, 0.9),
+    shot_on_target = c(TRUE, TRUE),
+    is_penalty = c(0L, 1L),                     # second shot is a penalty
+    stringsAsFactors = FALSE
+  )
+  lineups <- data.frame(
+    match_id = "m1", player_id = "A", player_name = "Pl A", team_id = "T",
+    minutes_played = 90, team_name = "Team", stringsAsFactors = FALSE
+  )
+  r <- suppressMessages(aggregate_player_xmetrics(spadl, lineups))
+  expect_equal(r$shots, 2)            # both shots still count in box-score
+  expect_equal(r$goals, 2)
+  expect_equal(r$n_xgot_shots, 1)     # only the non-penalty shot
+  expect_equal(r$xgot_placement, 0.5) # (0.7-0.2) — penalty excluded
+  expect_equal(r$xgot, 0.7)
+})
+
+test_that("predict_xgot aborts when a model feature column is missing", {
+  fake <- list(panna_metadata = list(
+    feature_cols = c("gm_y", "gm_z", "dist_to_near_post", "dist_to_top_corner")))
+  df <- data.frame(gm_y = 50, gm_z = 5, dist_to_near_post = 4)  # missing dist_to_top_corner
+  expect_error(predict_xgot(fake, df), "missing feature")
+})
+
+test_that("add_xgot_to_spadl assigns xgot correctly (realign, 0/NA matrix, own-goal, dedup)", {
+  # Mock the model prediction so we test the assignment logic deterministically.
+  testthat::local_mocked_bindings(
+    predict_xgot = function(xgot_model, shot_features) rep(0.5, nrow(shot_features))
+  )
+  spadl <- data.frame(
+    match_id = "m", original_event_id = 1:6, action_type = "shot",
+    start_x = c(85, 85, 85, 85, 3, 85),         # event 5 = own-goal origin (x < 50)
+    start_y = 50, bodypart = "foot_right", stringsAsFactors = FALSE
+  )
+  # lookup: shuffled order, event 1 DUPLICATED (dedup test), events 4 & 6 absent
+  lookup <- data.frame(
+    match_id = "m",
+    event_id = c(3, 1, 2, 5, 1),
+    type_id  = c(16L, 16L, 15L, 16L, 16L),      # goal/goal/saved/goal/(dup)
+    goalmouth_y = c(50, 51, NA, 50, 51),        # event 2 on-target but NO coords
+    goalmouth_z = c(5, 3, NA, 5, 3),
+    situation = "OpenPlay", stringsAsFactors = FALSE
+  )
+  r <- suppressWarnings(suppressMessages(add_xgot_to_spadl(spadl, list(), lookup)))
+  expect_equal(nrow(r), 6)                       # dedup -> no row inflation/crash
+  expect_equal(r$xgot[1], 0.5)                   # on-target + coords -> pred
+  expect_true(is.na(r$xgot[2]))                  # on-target, no coords -> NA
+  expect_equal(r$xgot[3], 0.5)                   # on-target + coords -> pred
+  expect_true(is.na(r$xgot[4]))                  # unmatched -> NA
+  expect_true(is.na(r$xgot[5]))                  # own-goal (type 16, x<50) -> NA
+  expect_true(is.na(r$xgot[6]))                  # unmatched -> NA
+  expect_equal(r$shot_on_target, c(TRUE, TRUE, TRUE, NA, TRUE, NA))
+})


### PR DESCRIPTION
## dev → main — xGOT PR-review fixes + EPV pipeline robustness

Follow-up to the merged xGOT PRs (#96), addressing the multi-agent review and hardening the EPV pipeline.

### xGOT review fixes (`b8a9189`)
- **Train/serve skew:** `add_xgot_to_spadl` now threads the real `situation` (was `NULL` → set-piece/corner/FK shots scored as open-play, disagreeing with the blog path).
- **No-silent-impute:** the xGOT decomposition columns (`placement_added`/`xgot_placement`/`targeting`/`xgot`) are no longer NA→0 filled; added `n_xgot_shots` coverage count and surface NA when a player has no usable xGOT signal.
- **Own-goal guard** in `add_xgot_to_spadl` (type 16, x<50 → NA).
- **De-dup** the goalmouth lookup key (a duplicate could misalign coords).
- **NA-preserving unmatched** shots — fixed an `NA %in% c(15,16) == FALSE` gotcha that mislabelled unmatched shots off-target (`xgot=0`) instead of NA. Caught by a new test.
- **Season filter** in `03_calculate_player_xmetrics` now uses `extract_season_end_year` (was a lexical string compare — the documented calendar-label trap).
- Distinguish a shot_events **load error** from absent coords; depersonalize comments.
- **Tests:** `add_xgot_to_spadl` assignment matrix, penalty exclusion, `predict_xgot` validation.

### EPV pipeline robustness/observability
- **`04899e8`** — upload models immediately after training, so a slow/cancelled xMetrics step can't skip publishing (it did on 2026-06-16).
- **`5f4ed3a`** — `[i/N]` load progress + ETA + per-model timers so long runs are legible.

Validation: `test-xgot-model` 25 pass, `test-xg-model` 35, `test-player-stats-opta` 103; package loads; docs regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
