### PR TITLE
Tiento composite + WC team-strength snapshot (+ held xG-ELO capability)

### DIFF
--- a/.github/workflows/predictions-pipeline.yml
+++ b/.github/workflows/predictions-pipeline.yml
@@ -214,7 +214,11 @@ jobs:
               # Archive a dated minutes snapshot + diff to the
               # wc2026-minutes-history release so group-stage drift is tracked
               # (blog-latest clobbers, so it retains no history of its own).
-              step_12b_snapshot_wc_minutes   = TRUE
+              step_12b_snapshot_wc_minutes   = TRUE,
+              # Same pattern for team strength: dated ELO + champion-odds
+              # snapshots to wc2026-strength-history so tournament rating drift
+              # is tracked going forward (no replay needed next time).
+              step_12c_snapshot_wc_strength  = TRUE
             )
 
             source('data-raw/match-predictions-opta/run_predictions_opta.R', chdir = FALSE)

--- a/R/match_prediction.R
+++ b/R/match_prediction.R
@@ -589,37 +589,69 @@ init_team_elos <- function(teams, initial_elo = 1500) {
 #' @param home_goals Goals scored by home team
 #' @param away_goals Goals scored by away team
 #' @param k K-factor controlling update magnitude (default 20)
-#' @param home_advantage Home advantage in Elo points (default 65)
+#' @param home_advantage Home advantage in Elo points (default 88)
+#' @param update_mode "outcome" (default) = W/D/L surprise x goal-difference
+#'   multiplier, the v6 production form. "margin_sqrt" = update toward a blended
+#'   goals/xG margin, sqrt-dampened (the xG-Elo form).
+#' @param home_xg,away_xg Expected goals per team (margin_sqrt mode only). When
+#'   either is NA the target falls back to actual goal difference (~35% of
+#'   matches have no shot data, so xG is unavailable for them).
+#' @param margin_slope Expected goal-margin per 400 Elo of gap, used as the
+#'   reference the result is judged against (margin_sqrt mode). Default 1.66.
+#' @param blend_w Weight on actual goal diff vs xG diff in the target margin:
+#'   perf = blend_w*GD + (1-blend_w)*xGD (margin_sqrt mode). Default 0.5.
 #'
 #' @return Named list with new_home_elo, new_away_elo
 #' @export
 update_elo <- function(home_elo, away_elo, home_goals, away_goals,
-                        k = 20, home_advantage = 88) {
+                        k = 20, home_advantage = 88,
+                        update_mode = c("outcome", "margin_sqrt"),
+                        home_xg = NA_real_, away_xg = NA_real_,
+                        margin_slope = 1.66, blend_w = 0.5) {
   stopifnot(length(home_goals) == 1, length(away_goals) == 1)
+  update_mode <- match.arg(update_mode)
 
-  # Expected scores
+  # Elo gap (already includes any home-advantage / venue adjustment passed in).
   diff <- (home_elo + home_advantage - away_elo) / 400
-  exp_home <- 1 / (1 + 10^(-diff))
-  exp_away <- 1 - exp_home
 
-
-  # Actual scores (1 = win, 0.5 = draw, 0 = loss)
-  if (home_goals > away_goals) {
-    actual_home <- 1
-  } else if (home_goals == away_goals) {
-    actual_home <- 0.5
-  } else {
-    actual_home <- 0
+  if (update_mode == "outcome") {
+    exp_home <- 1 / (1 + 10^(-diff))
+    exp_away <- 1 - exp_home
+    # Actual scores (1 = win, 0.5 = draw, 0 = loss)
+    if (home_goals > away_goals) {
+      actual_home <- 1
+    } else if (home_goals == away_goals) {
+      actual_home <- 0.5
+    } else {
+      actual_home <- 0
+    }
+    actual_away <- 1 - actual_home
+    # Goal difference multiplier (rewards larger margins)
+    goal_diff <- abs(home_goals - away_goals)
+    gd_mult <- log(goal_diff + 1) + 1
+    return(list(
+      new_home_elo = home_elo + k * gd_mult * (actual_home - exp_home),
+      new_away_elo = away_elo + k * gd_mult * (actual_away - exp_away)
+    ))
   }
-  actual_away <- 1 - actual_home
 
-  # Goal difference multiplier (rewards larger margins)
-  goal_diff <- abs(home_goals - away_goals)
-  gd_mult <- log(goal_diff + 1) + 1
-
+  # margin_sqrt: update toward a blended "true score" margin. perf_margin blends
+  # actual goal diff with xG diff (xG carries the bulk of the signal — less noisy
+  # per match), falling back to goal diff alone where xG is missing. The surprise
+  # (perf_margin - expected_margin) is sqrt-dampened so a blowout or a mis-scraped
+  # scoreline can't detonate the rating; expected_margin scales with the Elo gap.
+  gd <- home_goals - away_goals
+  perf_margin <- if (!is.na(home_xg) && !is.na(away_xg)) {
+    blend_w * gd + (1 - blend_w) * (home_xg - away_xg)
+  } else {
+    gd
+  }
+  dev <- perf_margin - margin_slope * diff
+  u <- sign(dev) * sqrt(abs(dev))
+  # Zero-sum: u is odd in the home POV, so away moves by exactly -u.
   list(
-    new_home_elo = home_elo + k * gd_mult * (actual_home - exp_home),
-    new_away_elo = away_elo + k * gd_mult * (actual_away - exp_away)
+    new_home_elo = home_elo + k * u,
+    new_away_elo = away_elo - k * u
   )
 }
 
@@ -666,6 +698,13 @@ update_elo <- function(home_elo, away_elo, home_goals, away_goals,
 #'   "now" for the decay calculation. Defaults to `max(match_date)` in
 #'   `results`.
 #'
+#' @param update_mode Passed to [update_elo()]: "outcome" (default) or
+#'   "margin_sqrt" (the xG-Elo form). When "margin_sqrt" and `results` carries
+#'   `home_xg`/`away_xg` columns, the update targets a blended goals/xG margin
+#'   (goal-diff fallback per row where xG is NA).
+#' @param blend_w,margin_slope Passed to [update_elo()] in margin_sqrt mode
+#'   (weight on goals vs xG, and expected-margin-per-400-Elo).
+#'
 #' @return A list with two elements:
 #'   - `per_match`: data frame with match_id, home_elo, away_elo, elo_diff
 #'     (pre-match Elo for each match in the input order)
@@ -679,7 +718,13 @@ compute_match_elos <- function(results, k = 20, home_advantage = 88,
                                 conf_priors = NULL,
                                 use_venue_factor = FALSE,
                                 time_decay_halflife = NULL,
-                                decay_reference_date = NULL) {
+                                decay_reference_date = NULL,
+                                update_mode = c("outcome", "margin_sqrt"),
+                                blend_w = 0.5, margin_slope = 1.66) {
+  update_mode <- match.arg(update_mode)
+  # margin_sqrt can use per-match xG when results carries it; else falls back to
+  # goal diff inside update_elo(). Detect the columns once.
+  has_xg_cols <- all(c("home_xg", "away_xg") %in% names(results))
   # time_decay_halflife (days, NULL = disabled): when set, scale K by
   # 0.5 ^ ((reference_date - match_date) / halflife) so older training
   # matches contribute exponentially less to the Elo trajectory than
@@ -786,7 +831,11 @@ compute_match_elos <- function(results, k = 20, home_advantage = 88,
       ha_eff <- home_advantage * venue_factor[i]
       updated <- update_elo(elos[ht], elos[at],
                             results$home_goals[i], results$away_goals[i],
-                            k = k_eff, home_advantage = ha_eff)
+                            k = k_eff, home_advantage = ha_eff,
+                            update_mode = update_mode,
+                            home_xg = if (has_xg_cols) results$home_xg[i] else NA_real_,
+                            away_xg = if (has_xg_cols) results$away_xg[i] else NA_real_,
+                            margin_slope = margin_slope, blend_w = blend_w)
       elos[ht] <- updated$new_home_elo
       elos[at] <- updated$new_away_elo
     }

--- a/data-raw/match-predictions-opta/12_export_wc2026_blog.R
+++ b/data-raw/match-predictions-opta/12_export_wc2026_blog.R
@@ -187,11 +187,12 @@ for (m in c("panna", "offense", "defense", "epr", "psr", "elo", "bt", "p_champ")
 
 # Tiento: composite team rating — computed HERE (pannaverse) instead of on ITG
 # (was inthegame-blog/football/wc-maps.js::computeTeamRating). A z-blend of the
-# headline metrics; weights are DATA-DRIVEN, not hand-set: a ridge of goal margin
-# on the standardized metric diffs (debug/_tiento_weights.R) gives panna 0.47 /
-# elo 0.36 / epr 0.17 / psr 0.00 — panna + Elo carry the signal, EPR less, and
-# PSR is redundant given the others (negative ridge coef -> dropped). The XGBoost
-# prediction model corroborates the ordering. Each metric is z-scored across the
+# headline metrics. The weights in TIENTO_WEIGHTS below are DATA-DRIVEN, not
+# hand-set: a ridge (alpha=0 cv.glmnet) of historical goal margin on the
+# standardized metric diffs, negative coefs clamped to 0 and renormalized to
+# sum 1 (derivation kept in data-raw/debug/keep/_tiento_weights.R). panna + Elo
+# carry most of the signal, EPR less, PSR drops out (its ridge coef came out
+# negative — redundant given the others). Each metric is z-scored across the
 # 48 teams (NA -> 0), then weighted-summed. ITG reads this `tiento` column
 # directly instead of recomputing the blend in the browser.
 TIENTO_WEIGHTS <- c(panna = 0.47, epr = 0.17, elo = 0.36, psr = 0.00)

--- a/data-raw/match-predictions-opta/12_export_wc2026_blog.R
+++ b/data-raw/match-predictions-opta/12_export_wc2026_blog.R
@@ -184,6 +184,25 @@ strength <- merge(strength, sim[, .(team, p_champ)], by = "team", all.x = TRUE)
 for (m in c("panna", "offense", "defense", "epr", "psr", "elo", "bt", "p_champ")) {
   strength[[paste0("rank_", m)]] <- frank(-strength[[m]], ties.method = "min")
 }
+
+# Tiento: composite team rating — computed HERE (pannaverse) instead of on ITG
+# (was inthegame-blog/football/wc-maps.js::computeTeamRating). A z-blend of the
+# headline metrics; weights are DATA-DRIVEN, not hand-set: a ridge of goal margin
+# on the standardized metric diffs (debug/_tiento_weights.R) gives panna 0.47 /
+# elo 0.36 / epr 0.17 / psr 0.00 — panna + Elo carry the signal, EPR less, and
+# PSR is redundant given the others (negative ridge coef -> dropped). The XGBoost
+# prediction model corroborates the ordering. Each metric is z-scored across the
+# 48 teams (NA -> 0), then weighted-summed. ITG reads this `tiento` column
+# directly instead of recomputing the blend in the browser.
+TIENTO_WEIGHTS <- c(panna = 0.47, epr = 0.17, elo = 0.36, psr = 0.00)
+.z_score <- function(v) {
+  m <- mean(v, na.rm = TRUE); s <- stats::sd(v, na.rm = TRUE)
+  if (is.na(s) || s == 0) rep(0, length(v)) else ifelse(is.na(v), 0, (v - m) / s)
+}
+strength[, tiento := rowSums(sapply(names(TIENTO_WEIGHTS),
+                  function(col) TIENTO_WEIGHTS[[col]] * .z_score(strength[[col]])))]
+strength[, rank_tiento := frank(-tiento, ties.method = "min")]
+
 setorder(strength, -p_champ)
 write_parquet(strength, file.path(cache_dir, "wc2026_team_strength.parquet"))
 message(sprintf("  wc2026_team_strength.parquet: %d teams x %d categories",

--- a/data-raw/match-predictions-opta/12c_snapshot_wc_strength.R
+++ b/data-raw/match-predictions-opta/12c_snapshot_wc_strength.R
@@ -1,0 +1,155 @@
+# 12c_snapshot_wc_strength.R
+# Archive a DATED snapshot of the WC2026 team-strength table (ELO + champion
+# odds + rating categories) and diff it against the previous snapshot, so we can
+# watch team ELO and p_champ drift across the tournament.
+#
+# Why this exists: step 12 uploads wc2026_team_strength.parquet to blog-latest,
+# which is CLOBBERED every run — only the latest survives, so there is no history
+# to diff (this is exactly why the kickoff ELO had to be reconstructed by replay).
+# This step writes wc2026_team_strength_<DATE>.parquet to a SEPARATE release tag
+# (wc2026-strength-history) that nothing clobbers and the blog's R2 sync ignores.
+# Mirrors 12b_snapshot_wc_minutes.R exactly; the only differences are the source
+# file, the key (team), and the diffed metrics (elo + p_champ).
+#
+# team_strength is FINAL at step 12 (downstream enrich_squads_piero.R only adds
+# `piero` to the SQUADS file, never team_strength), so the step-12 cache file is
+# the authoritative value.
+#
+# Idempotent within a day (--clobber). Sourced with local = TRUE from
+# run_predictions_opta.R, so the body is wrapped in a function.
+
+suppressPackageStartupMessages({ library(data.table); library(arrow) })
+
+.snapshot_wc_strength <- function() {
+  cache_dir <- if (exists("cache_dir", inherits = TRUE)) {
+    get("cache_dir", inherits = TRUE)
+  } else file.path("data-raw", "cache-predictions-opta")
+  repo <- "peteowen1/pannadata"
+  tag  <- "wc2026-strength-history"
+
+  src_path <- file.path(cache_dir, "wc2026_team_strength.parquet")
+  if (!file.exists(src_path)) {
+    message("  wc2026_team_strength.parquet not in cache — run step 12 first; skipping snapshot")
+    return(invisible(NULL))
+  }
+
+  today      <- Sys.Date()
+  key_cols   <- "team"
+  diff_cols  <- c("elo", "p_champ")        # the metrics that actually move
+  keep_cols  <- c("team", "group", "elo", "p_champ", "panna", "epr", "psr", "bt")
+
+  curr <- as.data.table(read_parquet(src_path))
+  miss <- setdiff(diff_cols, names(curr))
+  if (length(miss)) {
+    warning("wc2026_team_strength.parquet missing ", paste(miss, collapse = ", "),
+            " — cannot snapshot strength", call. = FALSE, immediate. = TRUE)
+    return(invisible(NULL))
+  }
+  curr <- curr[, intersect(keep_cols, names(curr)), with = FALSE]
+
+  snap_name  <- sprintf("wc2026_team_strength_%s.parquet", today)
+  snap_local <- file.path(cache_dir, snap_name)
+  write_parquet(curr, snap_local)
+  message(sprintf("  Snapshot written: %s (%d teams)", snap_name, nrow(curr)))
+
+  no_upload <- isTRUE(Sys.getenv("WC2026_NO_UPLOAD", "") == "1")
+  gh_ok <- !is.null(tryCatch(system2("gh", "--version", stdout = TRUE, stderr = TRUE),
+                             error = function(e) NULL))
+  gh_run <- function(args) system2("gh", args, stdout = TRUE, stderr = TRUE)
+  gh_failed <- function(res) !is.null(attr(res, "status")) && attr(res, "status") != 0
+
+  # --- find + download the most recent PRIOR snapshot ------------------------
+  prev <- NULL; prev_date <- NA
+  if (gh_ok && !no_upload) {
+    assets <- gh_run(c("release", "view", tag, "--repo", repo,
+                       "--json", "assets", "--jq", ".assets[].name"))
+    if (gh_failed(assets)) {
+      message("  No ", tag, " release yet — this snapshot becomes the baseline")
+      assets <- character(0)
+    }
+    snaps <- grep("^wc2026_team_strength_\\d{4}-\\d{2}-\\d{2}\\.parquet$", assets, value = TRUE)
+    if (length(snaps) > 0) {
+      dates <- as.Date(sub("^wc2026_team_strength_(\\d{4}-\\d{2}-\\d{2})\\.parquet$", "\\1", snaps))
+      prior <- dates[dates < today]
+      if (length(prior) > 0) {
+        prev_date  <- max(prior)
+        prev_name  <- sprintf("wc2026_team_strength_%s.parquet", prev_date)
+        prev_local <- file.path(cache_dir, prev_name)
+        dl <- gh_run(c("release", "download", tag, "--repo", repo,
+                       "--pattern", prev_name, "--dir", cache_dir, "--clobber"))
+        if (!gh_failed(dl) && file.exists(prev_local)) {
+          prev <- as.data.table(read_parquet(prev_local))
+          message(sprintf("  Prior snapshot: %s (%d teams)", prev_name, nrow(prev)))
+        } else {
+          warning("Could not download prior snapshot ", prev_name,
+                  " (listed on the release but fetch failed) — drift diff skipped this run",
+                  call. = FALSE, immediate. = TRUE)
+        }
+      } else {
+        message("  No prior dated snapshot before ", today, " — baseline only, no diff")
+      }
+    }
+  } else {
+    message("  gh unavailable or WC2026_NO_UPLOAD=1 — snapshot kept local, no upload/diff")
+  }
+
+  # --- compute the diff (per-team elo + p_champ deltas) ----------------------
+  diff_files <- character(0)
+  if (!is.null(prev) && all(diff_cols %in% names(prev))) {
+    diff_name  <- sprintf("wc2026_strength_diff_%s.csv", today)
+    diff_local <- file.path(cache_dir, diff_name)
+
+    pc <- prev[, c(key_cols, diff_cols), with = FALSE]
+    setnames(pc, diff_cols, paste0(diff_cols, "_prev"))
+    cc <- curr[, c(key_cols, "group", diff_cols), with = FALSE]
+    setnames(cc, diff_cols, paste0(diff_cols, "_curr"))
+
+    d <- merge(cc, pc, by = key_cols, all = TRUE)
+    d[, elo_delta     := round(elo_curr - elo_prev, 1)]
+    d[, p_champ_delta := round(p_champ_curr - p_champ_prev, 2)]
+    setorder(d, -elo_delta)
+    write.csv(d, diff_local, row.names = FALSE)
+    diff_files <- diff_local
+
+    mv <- d[!is.na(elo_delta)]
+    message(sprintf("\n  === Strength drift %s -> %s ===", prev_date, today))
+    message(sprintf("  %d teams compared | mean |elo delta| = %.1f | max = %.1f",
+                    nrow(mv), mean(abs(mv$elo_delta), na.rm = TRUE),
+                    max(abs(mv$elo_delta), na.rm = TRUE)))
+    fmt <- function(x) sprintf("    elo %+6.1f  p_champ %+5.2f  %-22s", x$elo_delta, x$p_champ_delta, x$team)
+    up   <- head(mv[order(-elo_delta)], 6); dn <- head(mv[order(elo_delta)], 6)
+    message("  Biggest ELO risers:");  for (i in seq_len(nrow(up))) message(fmt(up[i]))
+    message("  Biggest ELO fallers:"); for (i in seq_len(nrow(dn))) message(fmt(dn[i]))
+  } else {
+    message("  No diff computed (no comparable prior snapshot).")
+  }
+
+  # --- upload dated snapshot (+ diff) to the history tag ---------------------
+  if (gh_ok && !no_upload) {
+    rel <- gh_run(c("release", "view", tag, "--repo", repo))
+    if (gh_failed(rel)) {
+      crt <- gh_run(c("release", "create", tag, "--repo", repo,
+               "--title", shQuote("WC2026 Team-Strength History"),
+               "--notes", shQuote("Dated snapshots of wc2026 team strength (ELO + champion odds) for drift tracking.")))
+      if (gh_failed(crt))
+        warning("Failed to create the ", tag, " release: ", paste(crt, collapse = "\n"),
+                call. = FALSE, immediate. = TRUE)
+    }
+    for (f in c(snap_local, diff_files)) {
+      res <- gh_run(c("release", "upload", tag, shQuote(f), "--repo", repo, "--clobber"))
+      if (gh_failed(res)) {
+        warning(sprintf("Failed to upload %s: %s", basename(f), paste(res, collapse = "\n")),
+                call. = FALSE, immediate. = TRUE)
+      } else {
+        message(sprintf("  Uploaded %s", basename(f)))
+      }
+    }
+  } else {
+    message("  Skipped upload (gh unavailable or WC2026_NO_UPLOAD=1).")
+  }
+
+  message("\n=== WC 2026 team-strength snapshot complete ===")
+  invisible(NULL)
+}
+
+.snapshot_wc_strength()

--- a/data-raw/match-predictions-opta/run_predictions_opta.R
+++ b/data-raw/match-predictions-opta/run_predictions_opta.R
@@ -64,7 +64,8 @@ if (!exists("run_steps")) {
     step_10d_export_shootout_wpa     = FALSE,  # Opt-in: export per-player penalty-shootout WPA
     step_11_simulate_wc2026          = FALSE,  # Opt-in: simulate the 2026 World Cup
     step_12_export_wc2026_blog       = FALSE,  # Opt-in: export WC2026 blog data
-    step_12b_snapshot_wc_minutes     = FALSE   # Opt-in: archive dated minutes snapshot + diff
+    step_12b_snapshot_wc_minutes     = FALSE,  # Opt-in: archive dated minutes snapshot + diff
+    step_12c_snapshot_wc_strength    = FALSE   # Opt-in: archive dated team-strength (ELO+p_champ) snapshot + diff
   )
 }
 
@@ -273,6 +274,16 @@ step_results[[12]] <- run_pred_step("export_wc2026_blog", 12, function() {
 
 step_results[["12b"]] <- run_pred_step("snapshot_wc_minutes", "12b", function() {
   source("data-raw/match-predictions-opta/12b_snapshot_wc_minutes.R", local = TRUE)
+})
+
+# 14g. Step 12c: Snapshot WC 2026 Team Strength ----
+# Archive a dated copy of wc2026_team_strength.parquet (ELO + p_champ + ratings)
+# to the wc2026-strength-history release and diff it against the previous
+# snapshot (tournament ELO/champion-odds drift tracking). Runs after step 12,
+# which writes the team_strength file this reads.
+
+step_results[["12c"]] <- run_pred_step("snapshot_wc_strength", "12c", function() {
+  source("data-raw/match-predictions-opta/12c_snapshot_wc_strength.R", local = TRUE)
 })
 
 # 15. Summary ----

--- a/man/compute_match_elos.Rd
+++ b/man/compute_match_elos.Rd
@@ -14,7 +14,10 @@ compute_match_elos(
   conf_priors = NULL,
   use_venue_factor = FALSE,
   time_decay_halflife = NULL,
-  decay_reference_date = NULL
+  decay_reference_date = NULL,
+  update_mode = c("outcome", "margin_sqrt"),
+  blend_w = 0.5,
+  margin_slope = 1.66
 )
 }
 \arguments{
@@ -57,6 +60,14 @@ not default but available for callers wanting FIFA/SPI-style recency.}
 \item{decay_reference_date}{Optional Date or date-coercible string used as
 "now" for the decay calculation. Defaults to \code{max(match_date)} in
 \code{results}.}
+
+\item{update_mode}{Passed to \code{\link[=update_elo]{update_elo()}}: "outcome" (default) or
+"margin_sqrt" (the xG-Elo form). When "margin_sqrt" and \code{results} carries
+\code{home_xg}/\code{away_xg} columns, the update targets a blended goals/xG margin
+(goal-diff fallback per row where xG is NA).}
+
+\item{blend_w, margin_slope}{Passed to \code{\link[=update_elo]{update_elo()}} in margin_sqrt mode
+(weight on goals vs xG, and expected-margin-per-400-Elo).}
 }
 \value{
 A list with two elements:

--- a/man/update_elo.Rd
+++ b/man/update_elo.Rd
@@ -10,7 +10,12 @@ update_elo(
   home_goals,
   away_goals,
   k = 20,
-  home_advantage = 88
+  home_advantage = 88,
+  update_mode = c("outcome", "margin_sqrt"),
+  home_xg = NA_real_,
+  away_xg = NA_real_,
+  margin_slope = 1.66,
+  blend_w = 0.5
 )
 }
 \arguments{
@@ -24,7 +29,21 @@ update_elo(
 
 \item{k}{K-factor controlling update magnitude (default 20)}
 
-\item{home_advantage}{Home advantage in Elo points (default 65)}
+\item{home_advantage}{Home advantage in Elo points (default 88)}
+
+\item{update_mode}{"outcome" (default) = W/D/L surprise x goal-difference
+multiplier, the v6 production form. "margin_sqrt" = update toward a blended
+goals/xG margin, sqrt-dampened (the xG-Elo form).}
+
+\item{home_xg, away_xg}{Expected goals per team (margin_sqrt mode only). When
+either is NA the target falls back to actual goal difference (~35\% of
+matches have no shot data, so xG is unavailable for them).}
+
+\item{margin_slope}{Expected goal-margin per 400 Elo of gap, used as the
+reference the result is judged against (margin_sqrt mode). Default 1.66.}
+
+\item{blend_w}{Weight on actual goal diff vs xG diff in the target margin:
+perf = blend_w*GD + (1-blend_w)*xGD (margin_sqrt mode). Default 0.5.}
 }
 \value{
 Named list with new_home_elo, new_away_elo

--- a/tests/testthat/test-match-prediction.R
+++ b/tests/testthat/test-match-prediction.R
@@ -51,6 +51,37 @@ test_that("update_elo remains zero-sum across many scenarios", {
   }
 })
 
+test_that("update_elo margin_sqrt mode is zero-sum", {
+  result <- update_elo(1500, 1500, home_goals = 2, away_goals = 0,
+                       update_mode = "margin_sqrt", home_xg = 1.8, away_xg = 0.4)
+  expect_equal(result$new_home_elo + result$new_away_elo, 3000, tolerance = 1e-10)
+})
+
+test_that("update_elo margin_sqrt: a heavy favourite who draws LOSES Elo", {
+  # Home far stronger -> expected to win by a margin; a 0-0 is a big
+  # underperformance, so home Elo drops (the Spain-0-0 behaviour the margin
+  # form exists to capture; a pure-outcome draw would barely move).
+  result <- update_elo(2000, 1400, home_goals = 0, away_goals = 0,
+                       update_mode = "margin_sqrt", margin_slope = 1.66)
+  expect_true(result$new_home_elo < 2000)
+})
+
+test_that("update_elo margin_sqrt: NA xG falls back to goal diff; xG flatters less", {
+  fallback <- update_elo(1500, 1500, 2, 0, update_mode = "margin_sqrt")  # xG NA -> GD
+  # A 2-0 with weak xG (a lucky scoreline) should move home LESS than the
+  # goal-diff-only update, because the blended margin is smaller.
+  low_xg <- update_elo(1500, 1500, 2, 0, update_mode = "margin_sqrt",
+                       home_xg = 0.8, away_xg = 0.6)
+  expect_true(low_xg$new_home_elo < fallback$new_home_elo)
+  expect_true(fallback$new_home_elo > 1500)  # still a win, still rises
+})
+
+test_that("update_elo defaults to outcome mode (back-compat)", {
+  default_mode <- update_elo(1600, 1400, 2, 1)
+  explicit     <- update_elo(1600, 1400, 2, 1, update_mode = "outcome")
+  expect_equal(default_mode$new_home_elo, explicit$new_home_elo)
+})
+
 
 test_that("compute_match_elos returns correct structure", {
   results <- data.frame(


### PR DESCRIPTION
`dev → main`. Headline: the WC team-rating tracking + the data-driven Tiento composite. Bundles 6 accumulated `dev` commits.

## Headline (this session's work)
- **`tiento` composite team rating, computed in pannaverse** (`12_export_wc2026_blog.R`) — moves it off ITG (`wc-maps.js::computeTeamRating`). **Data-driven weights** (ridge of goal margin on standardized metric diffs): panna 0.47 / elo 0.36 / epr 0.17 / **psr 0.00** (PSR redundant — negative coef, dropped), vs ITG's hand-set .35/.25/.25/.15. The XGBoost match model corroborates the ordering. → **ITG handoff:** read the `tiento` column instead of recomputing the z-blend in the browser.
- **`12c_snapshot_wc_strength`** — dated `team_strength` (ELO + champion-odds) snapshots to a `wc2026-strength-history` release, so team ratings are tracked over the tournament. Merging activates it (runs from `main`).
- **`update_elo` margin-sqrt + xG-blend mode** — built **inert / non-default** (outcome mode stays the default). The full xG-ELO was rigorously evaluated and a re-train gate showed it does **not** improve production predictions (the gain washes out — ELO is a minor, redundant feature), so it was **HELD**. Nothing is enabled; this is a clean, tested capability kept available for a possible future intl-specific use. See `pannaverse/XG_ELO_AND_COMPOSITES_PLAN.md`.

## Prior `dev` work coming along (already reviewed)
- xGOT PR-review fixes (train/serve skew, own-goal, NA-impute, dedup); EPV training CI (upload-before-xmetrics) + load-progress/timers.

## Notes
- 54 match-prediction tests pass. Production behaviour is unchanged by the ELO capability (default = outcome). Tiento is purely additive (a new column).

🤖 Generated with [Claude Code](https://claude.com/claude-code)