### PR TITLE
PSR league offsets: decay-weighted blend end-add (consistency with EPR)

### DIFF
--- a/data-raw/estimated-skills/08b_export_psr_weekly.R
+++ b/data-raw/estimated-skills/08b_export_psr_weekly.R
@@ -296,35 +296,34 @@ psr_lg_col <- if ("competition" %in% names(match_stats)) "competition" else
 psr_apply_offsets <- !is.null(psr_offsets) && !is.null(psr_lg_col) &&
                      "total_minutes" %in% names(match_stats)
 if (psr_apply_offsets) {
+  # DECAY-WEIGHTED BLEND of league offsets (not a single primary league): each
+  # game contributes its league's offset, weighted by PSR's OWN skill recency
+  # (decay_params$rate, ~231-day half-life) so the blend matches how the smoothed
+  # skills weight games. End-added per player below. This handles mid-season
+  # movers correctly (a 60/40 split gets a blended discount, converging as the
+  # window fills) instead of snapping to the single max-minutes league. Mirrors
+  # the EPR decay-blend; PSR uses its shorter decay, not EPR's 900d.
   pl_src <- match_stats[!is.na(get(psr_lg_col)),
                         .(player_id, .lg = get(psr_lg_col),
                           match_date, total_minutes)]
-  PSR_LEAGUE_WINDOW_DAYS <- 365L
-  # Primary league as of date d: max-minutes competition in the trailing
-  # window, else max-minutes competition all-time before d.
-  .primary_league_asof <- function(d) {
-    hist <- pl_src[match_date < d]
+  PSR_BLEND_LAMBDA <- decay_params$rate          # per-day; ~231d half-life
+  blend_src <- merge(pl_src,
+                     data.table::as.data.table(psr_offsets)[, .(.lg = league, .off = offset)],
+                     by = ".lg", all.x = TRUE)
+  blend_src[is.na(.off), .off := 0]              # leagues without an offset contribute 0
+  .maxmd_psr <- as.numeric(max(blend_src$match_date))
+  # gfac = exp(-lambda*(d - md))*mins; the exp(-lambda*d) common factor cancels in
+  # the blend ratio, so precompute the max-date-shifted per-game weight once.
+  blend_src[, gfac := exp(-PSR_BLEND_LAMBDA * (.maxmd_psr - as.numeric(match_date))) * total_minutes]
+  blend_src[, woff := gfac * .off]
+  data.table::setkey(blend_src, match_date)
+  .blend_offset_asof <- function(d) {
+    hist <- blend_src[match_date < d]
     if (!nrow(hist)) return(NULL)
-    .pick <- function(x) {
-      if (!nrow(x)) return(NULL)
-      a <- x[, .(m = sum(total_minutes, na.rm = TRUE)), by = .(player_id, .lg)]
-      data.table::setorder(a, player_id, -m)
-      a[, .(league = .lg[1L]), by = player_id]
-    }
-    recent <- .pick(hist[match_date >= d - PSR_LEAGUE_WINDOW_DAYS])
-    allt   <- .pick(hist)
-    if (is.null(allt)) return(recent)
-    if (is.null(recent)) return(allt)
-    # Prefer the trailing-window league; fall back to all-time for players
-    # with no minutes in the window (injured/returning).
-    out <- merge(allt, recent, by = "player_id", all.x = TRUE,
-                 suffixes = c("_all", "_recent"))
-    out[, league := data.table::fifelse(is.na(league_recent),
-                                        league_all, league_recent)]
-    out[, .(player_id, league)]
+    hist[, .(.boff = sum(woff) / sum(gfac)), by = player_id]
   }
-  cat(sprintf("  PSR league offsets loaded (%d leagues); primary-league source built (%s, %d-day window)\n",
-              nrow(psr_offsets), psr_lg_col, PSR_LEAGUE_WINDOW_DAYS))
+  cat(sprintf("  PSR league offsets loaded (%d leagues); decay-weighted blend built (%s, lambda=%.4f ~ %d-day half-life)\n",
+              nrow(psr_offsets), psr_lg_col, PSR_BLEND_LAMBDA, round(log(2) / PSR_BLEND_LAMBDA)))
 } else {
   cat(sprintf("  NOTE: PSR league offsets %s -> not applied\n",
               if (is.null(psr_offsets)) "not found (run step 06 first)" else "disabled (no competition/minutes)"))
@@ -498,16 +497,21 @@ for (i in seq_along(snapshot_dates)) {
   )
   if (is.null(psr) || nrow(psr) == 0) { rm(skills, psr); next }
 
-  # Cross-league calibration: attach the player's current league (as of d) and
-  # add the transfer-graph offset so weak-league players aren't ranked globally.
+  # Cross-league calibration: end-add the decay-weighted blend of league offsets
+  # (full strength, split osr/dsr to preserve osr+dsr=psr) so weak-league players
+  # aren't ranked globally and mid-season movers blend across leagues.
   if (psr_apply_offsets) {
     psr <- data.table::as.data.table(psr)
-    if ("league" %in% names(psr)) psr[, league := NULL]
-    pl_d <- .primary_league_asof(d)
-    if (!is.null(pl_d)) {
-      psr <- merge(psr, pl_d, by = "player_id", all.x = TRUE)
-      psr <- apply_psr_league_offsets(psr, psr_offsets)
-      psr[, league := NULL]
+    bl <- .blend_offset_asof(d)
+    if (!is.null(bl)) {
+      psr <- merge(psr, bl, by = "player_id", all.x = TRUE)
+      psr[is.na(.boff), .boff := 0]
+      psr[, psr := psr + .boff]
+      if (all(c("osr", "dsr") %in% names(psr))) {
+        psr[, osr := osr + .boff / 2]
+        psr[, dsr := dsr + .boff / 2]
+      }
+      psr[, .boff := NULL]
     }
   }
 

--- a/data-raw/estimated-skills/_run_psr_blend_migration.R
+++ b/data-raw/estimated-skills/_run_psr_blend_migration.R
@@ -1,0 +1,102 @@
+# ONE-TIME migration: convert the live opta_psr_weekly from PRIMARY-LEAGUE offsets
+# to the DECAY-WEIGHTED BLEND offsets (matching 08b's new method). A full 08b
+# rebuild is ~4h (skill re-estimation), but the offset is END-ADD/additive, so we
+# can migrate the existing parquet: strip the primary-league offset that was
+# applied, then add the blend offset. Both are recomputed from the SAME match_stats
+# + psr_offsets 08b used, so the strip is exact.
+#
+# Self-check: after stripping, a weak-league name (J. Randall / A_League) must pop
+# back near the top (confirms the live parquet really had primary offsets); after
+# adding the blend it must drop again. Aborts if the strip doesn't recover the
+# inflated state (=> live parquet isn't primary-offset as assumed).
+#
+# Set TEST_ONLY <- TRUE to verify without writing.
+suppressMessages({devtools::load_all(".", quiet = TRUE); library(arrow); library(data.table)})
+
+TEST_ONLY <- if (exists("TEST_ONLY")) TEST_ONLY else TRUE
+cache_dir <- file.path("data-raw", "cache-skills")
+opta_dir  <- opta_data_dir()
+weekly_path <- file.path(opta_dir, "opta_psr_weekly.parquet")
+
+cat("=== Loading ===\n")
+weekly <- as.data.table(read_parquet(weekly_path))
+weekly[, snapshot_date := as.Date(snapshot_date)]
+out_cols <- names(weekly)
+offsets <- as.data.table(read_parquet(file.path(cache_dir, "psr_league_offsets.parquet")))
+
+ms_path <- { p <- file.path(cache_dir, "01_match_stats_slim.rds")
+             if (file.exists(p)) p else file.path(cache_dir, "01_match_stats.rds") }
+ms <- as.data.table(readRDS(ms_path))
+if (!inherits(ms$match_date, "Date")) ms[, match_date := as.Date(ms$match_date)]
+lgcol <- if ("competition" %in% names(ms)) "competition" else "league"
+
+# --- primary-league (what was applied) ---
+pl_src <- ms[!is.na(get(lgcol)), .(player_id, .lg = get(lgcol), match_date, total_minutes)]
+WIN <- 365L
+.primary_asof <- function(d) {
+  hist <- pl_src[match_date < d]; if (!nrow(hist)) return(NULL)
+  pk <- function(x){ if(!nrow(x)) return(NULL); a<-x[,.(m=sum(total_minutes,na.rm=TRUE)),by=.(player_id,.lg)]; setorder(a,player_id,-m); a[,.(league=.lg[1L]),by=player_id] }
+  r<-pk(hist[match_date>=d-WIN]); a<-pk(hist)
+  if(is.null(a))return(r); if(is.null(r))return(a)
+  o<-merge(a,r,by="player_id",all.x=TRUE,suffixes=c("_all","_recent")); o[,league:=fifelse(is.na(league_recent),league_all,league_recent)]; o[,.(player_id,league)]
+}
+off_lk <- offsets[, .(league, .off = offset)]
+
+# --- decay-weighted blend (new) — match PSR skill recency ---
+dp <- if (file.exists(file.path(cache_dir, "02b_decay_params.rds"))) readRDS(file.path(cache_dir,"02b_decay_params.rds")) else get_default_decay_params()
+LAMBDA <- dp$rate
+blend_src <- merge(pl_src, offsets[, .(.lg = league, .o = offset)], by = ".lg", all.x = TRUE)
+blend_src[is.na(.o), .o := 0]
+mm <- as.numeric(max(blend_src$match_date))
+blend_src[, gfac := exp(-LAMBDA * (mm - as.numeric(match_date))) * total_minutes]
+blend_src[, wo := gfac * .o]; setkey(blend_src, match_date)
+.blend_asof <- function(d){ h<-blend_src[match_date<d]; if(!nrow(h)) return(NULL); h[,.(boff=sum(wo)/sum(gfac)),by=player_id] }
+
+cat(sprintf("  weekly: %s rows, %d dates | lambda=%.4f (~%dd half-life)\n",
+            format(nrow(weekly),big.mark=","), uniqueN(weekly$snapshot_date), LAMBDA, round(log(2)/LAMBDA)))
+
+apply_one <- function(pdt, d) {
+  prim <- .primary_asof(d)
+  primoff <- if (!is.null(prim)) merge(prim, off_lk, by="league", all.x=TRUE)[is.na(.off), .off:=0][, .(player_id, primoff=.off)] else NULL
+  bl <- .blend_asof(d)
+  pdt <- merge(pdt, if(!is.null(primoff)) primoff else data.table(player_id=character(),primoff=numeric()), by="player_id", all.x=TRUE)
+  pdt <- merge(pdt, if(!is.null(bl)) bl else data.table(player_id=character(),boff=numeric()), by="player_id", all.x=TRUE)
+  pdt[is.na(primoff), primoff:=0][is.na(boff), boff:=0]
+  pdt[, delta := boff - primoff]                       # strip primary, add blend
+  pdt[, psr := psr + delta][, osr := osr + delta/2][, dsr := dsr + delta/2]
+  pdt[, c("primoff","boff","delta") := NULL]
+  pdt
+}
+
+# Self-check on latest date: strip-only should re-inflate Randall; full should drop him
+dlate <- max(weekly$snapshot_date)
+late <- copy(weekly[snapshot_date==dlate])
+prim <- .primary_asof(dlate); primoff <- merge(prim, off_lk, by="league", all.x=TRUE)[is.na(.off),.off:=0][,.(player_id,primoff=.off)]
+stripped <- merge(copy(late), primoff, by="player_id", all.x=TRUE)[is.na(primoff),primoff:=0]
+stripped[, psr_free := psr - primoff]
+rj_stripped_rank <- { setorder(stripped, -psr_free); which(grepl("Randall", stripped$player_name))[1] }
+cat(sprintf("\nSELF-CHECK @ %s: J. Randall rank after STRIP (offset-free) = %s of %d\n",
+            as.character(dlate), rj_stripped_rank, nrow(stripped)))
+if (is.na(rj_stripped_rank) || rj_stripped_rank > 200) {
+  stop("Strip did NOT re-inflate Randall (rank ", rj_stripped_rank, ") — live parquet is not primary-offset as assumed. ABORT.")
+}
+cat("  -> strip recovers the inflated offset-free state. Safe to migrate.\n")
+
+cat("\n=== Applying blend across all dates ===\n")
+dates <- sort(unique(weekly$snapshot_date))
+res <- vector("list", length(dates))
+for (i in seq_along(dates)) {
+  res[[i]] <- apply_one(weekly[snapshot_date==dates[i]], dates[i])[, ..out_cols]
+}
+out <- rbindlist(res, use.names=TRUE); setorder(out, snapshot_date, player_id)
+
+latest <- out[snapshot_date==max(snapshot_date)][order(-psr)]
+cat(sprintf("\n=== Top 12 @ %s (blend offsets) ===\n", as.character(max(out$snapshot_date))))
+print(latest[1:12, .(player_name, primary_position, psr=round(psr,3), weighted_90s=round(weighted_90s,1))])
+rj <- latest[grepl("Randall", player_name)]
+if (nrow(rj)) cat(sprintf("  J. Randall: psr=%.3f rank %d of %d\n", rj$psr[1], which(latest$player_id==rj$player_id[1])[1], nrow(latest)))
+
+if (TEST_ONLY) { cat("\n[TEST_ONLY] not written.\n") } else {
+  write_parquet(as.data.frame(out), weekly_path)
+  cat(sprintf("\n=== WROTE %s (%s rows, %d dates) ===\n", weekly_path, format(nrow(out),big.mark=","), uniqueN(out$snapshot_date)))
+}


### PR DESCRIPTION
## What
PSR's 08b applied the league offset by a single **primary league** (max-minutes) — the mid-season-mover limitation EPR just fixed. Switch to the **decay-weighted blend** across every league a player played, weighted by **PSR's own skill recency** (`decay_params$rate`, ~231-day half-life, not EPR's 900d — PSR's memory lives in the smoothed skills). End-added at full strength, split osr/dsr.

Single-league players are unchanged (blend = primary); only movers blend.

## Deploy
A full 08b rebuild is ~4h (skill re-estimation), but the offset is additive, so deploy is a **one-time migration** (`_run_psr_blend_migration.R`): strip the primary offset baked into the live parquet, add the blend (both recomputed from the same match_stats + psr_offsets → exact). Self-checks that stripping re-inflates J. Randall (A_League → rank 8) before re-applying. After this, 08b's weekly incremental stays blend-consistent.

Bundled to R2 with the EPR rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)