### PR TITLE
docs(pkgdown): index cross-league offset functions (green the docs build)

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -246,6 +246,14 @@ reference:
   - simulate_world_cup
   - run_wc2026_reference_checks
 
+- title: Cross-League Offsets
+  desc: Per-league PSR/EPR calibration via the same-season co-occurrence network
+  contents:
+  - build_league_network
+  - compute_psr_league_offsets
+  - apply_psr_league_offsets
+  - apply_epr_league_offsets
+
 - title: Weather
   desc: Open-Meteo weather data for match conditions
   contents:


### PR DESCRIPTION
After #116/#118, the pkgdown docs build on main was failing — 4 exported functions (build_league_network, compute_psr_league_offsets, apply_psr/epr_league_offsets) had Rd topics but no _pkgdown.yml entry. Adds a Cross-League Offsets section. R-CMD-check was already green; this only affects the docs site (pkgdown runs on push-to-main, so it verifies after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)