### PR TITLE
docs(pkgdown): drop stale load_epv_model ref (green main)

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -133,7 +133,6 @@ reference:
   - assign_epv_credit
   - aggregate_player_epv
   - save_epv_model
-  - load_epv_model
   - pb_download_epv_models
   - validate_epv_model
   - fit_xg_model


### PR DESCRIPTION
#120 committed the deletion of man/load_epv_model.Rd (fn went internal in the EPV overhaul), leaving a dangling _pkgdown.yml entry → pkgdown failed on the main push. Removes it. R-CMD-check unaffected (config-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)