### PR TITLE
Add WC finals-week daily cron backstop (Jul 12-19)

### DIFF
--- a/.github/workflows/predictions-pipeline.yml
+++ b/.github/workflows/predictions-pipeline.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     # Wednesday 8 AM UTC — after Tuesday matches + overnight Opta scrape
     - cron: '0 8 * * 3'
+    # WC 2026 finals week (Jul 12-19): daily 9 AM UTC backstop in case the
+    # 05:00 scrape's opta-scrape-complete dispatch fails. Cron has no year
+    # field so this re-fires on these July dates every year - harmless
+    # (concurrency-queued, idempotent); remove after the 2026 final.
+    - cron: '0 9 12-19 7 *'
   workflow_dispatch:
     inputs:
       force_rebuild:


### PR DESCRIPTION
The wc2026 model parquets refresh only via the 05:00 UTC scrape's `opta-scrape-complete` dispatch; if that fails during finals week, the next automatic run was Wednesday's weekly cron — up to ~6 days of stale team strengths / knockout lambdas during the highest-traffic week. Adds a self-date-limited daily backstop: `0 9 12-19 7 *` (daily 09:00 UTC, July 12–19 only). Cron has no year field so it re-fires those dates in future Julys — harmless (concurrency-queued, idempotent); remove after the final.

Requested by Pete 2026-07-12 (WC readiness review finding). Hotfix branch off main deliberately — dev carries unreviewed work in flight. YAML validated; one-line schedule addition only, no job changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WThKistEGviQWECsby6gx