### PR TITLE
dev -> main: GSAA/duel-WOE blog export + xGOT own-goal qualifier fix

### DIFF
--- a/R/xgot_model.R
+++ b/R/xgot_model.R
@@ -115,6 +115,20 @@ prepare_shots_for_xgot <- function(shot_events,
   on_target <- shot_events$type_id %in% XGOT_ON_TARGET_TYPE_IDS
   shot_events <- shot_events[on_target, , drop = FALSE]
 
+  # Drop own goals from TRAINING: they enter as guaranteed-goal rows with
+  # degenerate pre-shot features (the xG model learned exactly this pattern
+  # -- ~0.98 at own-end coords, see epv_model.R's own-goal override).
+  # opta_shot_events carries no qualifier-28 column, so detection here is
+  # positional (type-16 goal at the scorer's own end); acceptable for
+  # training exclusion where a false positive costs one row, unlike the
+  # serving path in add_xgot_to_spadl() which uses the SPADL is_own_goal
+  # marker (#148).
+  is_og <- shot_events$type_id == 16L & !is.na(shot_events$x) & shot_events$x < 50
+  if (any(is_og)) {
+    cli::cli_alert_info("Dropping {sum(is_og)} own goal{?s} from xGOT training.")
+    shot_events <- shot_events[!is_og, , drop = FALSE]
+  }
+
   # Complete-window gate (goalmouth coords reliable only from 2021-22+).
   if ("season" %in% names(shot_events)) {
     ey <- vapply(shot_events$season, extract_season_end_year, numeric(1))
@@ -367,11 +381,28 @@ add_xgot_to_spadl <- function(spadl_actions, xgot_model, goalmouth_lookup) {
     xgot_vec[predable] <- predict_xgot(xgot_model, cbind(base, plc))
   }
 
-  # Own-goal guard: an own goal is logged type 16 at the scorer's own end
-  # (start_x < 50). Its goal-mouth placement is meaningless for the shooter ->
-  # NA, mirroring enrich_shots_xgot.R + the own-goal xG convention (CLAUDE.md).
-  is_og <- joined$type_id == 16L & !is.na(shots$start_x) & shots$start_x < 50
-  is_og[is.na(is_og)] <- FALSE
+  # Own-goal guard: goal-mouth placement is meaningless for the "shooter" ->
+  # NA, mirroring the own-goal xG convention (CLAUDE.md). Prefer the explicit
+  # Opta qualifier-28 marker (optional SPADL column); the positional fallback
+  # (type-16 goal at the scorer's own end) only covers stale cached SPADL that
+  # predates the column -- it misreads a legitimate goal logged past halfway
+  # (#148).
+  pos_og <- joined$type_id == 16L & !is.na(shots$start_x) & shots$start_x < 50
+  pos_og[is.na(pos_og)] <- FALSE
+  if (!"is_own_goal" %in% names(shots)) {
+    cli::cli_warn("spadl_actions lacks is_own_goal - using positional own-goal fallback (type-16 goal at start_x < 50); rebuild the SPADL cache for qualifier-based detection.")
+    is_og <- pos_og
+  } else {
+    is_og <- shots$is_own_goal %in% TRUE
+    # rbindlist(fill=TRUE) over mixed-vintage SPADL chunks yields NA for rows
+    # from caches that predate the column -- fall back per-row there rather
+    # than silently treating NA as "not an own goal".
+    og_na <- is.na(shots$is_own_goal)
+    if (any(og_na)) {
+      cli::cli_warn("{sum(og_na)} shot{?s} carry NA is_own_goal (mixed-vintage SPADL cache?) - positional own-goal fallback applied to those rows.")
+      is_og <- is_og | (og_na & pos_og)
+    }
+  }
   xgot_vec[is_og] <- NA_real_
 
   spadl_actions$xgot[shot_idx] <- xgot_vec

--- a/data-raw/match-predictions-opta/10b_export_game_logs.R
+++ b/data-raw/match-predictions-opta/10b_export_game_logs.R
@@ -559,7 +559,14 @@ validate_game_log_schema <- function(dt, league, season) {
         xg_disp <- data.table::as.data.table(
           load_opta_xmetrics(league, season = league_season,
                              source = xm_source, by_match = TRUE))
-        disp_cols <- intersect(c("goals_minus_xgot", "placement_added", "xgot"),
+        # GSAA + duel WOE ride the same per-match xMetrics table as the trio —
+        # display-only columns for the blog's Defending/Duels tabs (requested
+        # 2026-07-18); intersect() keeps this NA-safe when a column is absent.
+        disp_cols <- intersect(c("goals_minus_xgot", "placement_added", "xgot",
+                                 "gsaa", "gsaa_per90", "xgot_faced", "goals_conceded",
+                                 "aerial_woe_per90", "aerial_poss_woe_per90",
+                                 "takeon_woe_per90", "tackle_poss_woe_per90",
+                                 "containment_woe_per90"),
                                names(xg_disp))
         if (length(disp_cols) > 0 && all(c("player_id", "match_id") %in% names(xg_disp))) {
           xg_disp <- unique(xg_disp[, c("player_id", "match_id", disp_cols), with = FALSE],
@@ -671,6 +678,9 @@ validate_game_log_schema <- function(dt, league, season) {
       "wpa_total", "wpa_as_actor", "wpa_as_receiver",
       "psv", "osv", "dsv",
       "goals_minus_xgot", "placement_added", "xgot",
+      "gsaa", "gsaa_per90", "xgot_faced", "goals_conceded",
+      "aerial_woe_per90", "aerial_poss_woe_per90",
+      "takeon_woe_per90", "tackle_poss_woe_per90", "containment_woe_per90",
       "piero_value_p90"),
     names(game_logs)
   )

--- a/tests/testthat/test-xgot-model.R
+++ b/tests/testthat/test-xgot-model.R
@@ -33,6 +33,25 @@ test_that("prepare_shots_for_xgot keeps only on-target, 2021+, coord-bearing sho
   expect_true(all(c("gm_y", "dist_to_near_post", "is_goal") %in% names(feat)))
 })
 
+test_that("prepare_shots_for_xgot drops own goals (type-16 goal at own end) from training", {
+  shots <- data.frame(
+    match_id = "m", event_id = 1:3, player_id = "p", player_name = "P",
+    x = c(80, 5, 82), y = 50,
+    type_id = c(16L, 16L, 15L),        # goal, OWN goal (x=5), saved
+    is_goal = c(1L, 1L, 0L),
+    season  = "2024-2025",
+    goalmouth_y = c(50, 51, 49), goalmouth_z = c(10, 3, 12),
+    body_part = "RightFoot", situation = "OpenPlay", big_chance = 0L,
+    stringsAsFactors = FALSE
+  )
+  feat <- suppressMessages(suppressWarnings(prepare_shots_for_xgot(shots)))
+  expect_equal(nrow(feat), 2)                    # own goal excluded
+  expect_false(2L %in% feat$event_id)
+  expect_equal(attr(feat, "placement_cols"),
+               c("gm_y", "gm_z", "dist_to_near_post", "dist_to_top_corner"))
+  expect_true(all(c("gm_y", "dist_to_near_post", "is_goal") %in% names(feat)))
+})
+
 test_that("aggregate_player_xmetrics emits a consistent finishing decomposition", {
   spadl <- data.frame(
     match_id = "m1", player_id = "A", player_name = "Pl A", team_id = "T",
@@ -114,4 +133,52 @@ test_that("add_xgot_to_spadl assigns xgot correctly (realign, 0/NA matrix, own-g
   expect_true(is.na(r$xgot[5]))                  # own-goal (type 16, x<50) -> NA
   expect_true(is.na(r$xgot[6]))                  # unmatched -> NA
   expect_equal(r$shot_on_target, c(TRUE, TRUE, TRUE, NA, TRUE, NA))
+})
+
+test_that("add_xgot_to_spadl prefers the is_own_goal qualifier over position (#148)", {
+  testthat::local_mocked_bindings(
+    predict_xgot = function(xgot_model, shot_features) rep(0.5, nrow(shot_features))
+  )
+  spadl <- data.frame(
+    match_id = "m", original_event_id = 1:3, action_type = "shot",
+    start_x = c(30, 85, 55),                     # 1 = legit long-range goal
+    start_y = 50, bodypart = "foot_right",
+    is_own_goal = c(FALSE, FALSE, TRUE),         # 3 = own goal logged past halfway
+    stringsAsFactors = FALSE
+  )
+  lookup <- data.frame(
+    match_id = "m", event_id = 1:3, type_id = 16L,   # all goals
+    goalmouth_y = 50, goalmouth_z = 5,
+    situation = "OpenPlay", stringsAsFactors = FALSE
+  )
+  # Qualifier branch must not fire the missing-column fallback warning.
+  expect_no_warning(r <- suppressMessages(add_xgot_to_spadl(spadl, list(), lookup)))
+  expect_equal(r$xgot[1], 0.5)     # x<50 but NOT an own goal -> scored, not NA
+  expect_equal(r$xgot[2], 0.5)
+  expect_true(is.na(r$xgot[3]))    # own goal past halfway -> NA via qualifier
+})
+
+test_that("add_xgot_to_spadl falls back positionally for NA is_own_goal rows", {
+  testthat::local_mocked_bindings(
+    predict_xgot = function(xgot_model, shot_features) rep(0.5, nrow(shot_features))
+  )
+  # Mixed-vintage cache shape: rbindlist(fill=TRUE) leaves NA on old chunks.
+  spadl <- data.frame(
+    match_id = "m", original_event_id = 1:3, action_type = "shot",
+    start_x = c(3, 85, 85), start_y = 50, bodypart = "foot_right",
+    is_own_goal = c(NA, NA, FALSE),
+    stringsAsFactors = FALSE
+  )
+  lookup <- data.frame(
+    match_id = "m", event_id = 1:3, type_id = 16L,
+    goalmouth_y = 50, goalmouth_z = 5,
+    situation = "OpenPlay", stringsAsFactors = FALSE
+  )
+  expect_warning(
+    r <- suppressMessages(add_xgot_to_spadl(spadl, list(), lookup)),
+    "NA is_own_goal"
+  )
+  expect_true(is.na(r$xgot[1]))    # NA marker + own-end goal -> positional NA
+  expect_equal(r$xgot[2], 0.5)     # NA marker, normal goal -> scored
+  expect_equal(r$xgot[3], 0.5)     # populated FALSE -> scored
 })


### PR DESCRIPTION
Two commits, both freeze-safe (nothing touches the predictions live path or served WP/EPV models; effects land via the Wednesday game-logs cron / next manual xGOT retrain).

**`1968b05` — Export GSAA + duel WOE columns to blog game-logs.** Adds the keeper shot-stopping block (gsaa, gsaa_per90, xgot_faced, goals_conceded) and the five `*_woe_per90` duel over-expected columns to step 10b's display join + blog_cols allowlist. The per-match xMetrics table already computes all nine — they just never made it into the export. Purely additive; `intersect()` keeps the join NA-safe and `validate_game_log_schema` only asserts required columns. The blog's Defending/Duels tabs (presence-guard wired on itg dev) light up on the next xmetrics-fresh game-logs build.

**`04e4185` — xGOT own-goal detection via qualifier, not position (fixes #148).** `add_xgot_to_spadl()` now uses the SPADL `is_own_goal` marker (Opta qualifier 28) instead of the `x<50` heuristic that misread any legitimate goal logged from the scorer's own half; the positional check survives only as a warned fallback (missing column, or per-row NA from mixed-vintage cache chunks — review catch). `prepare_shots_for_xgot()` additionally drops own goals from training: 5,782 guaranteed-goal rows with degenerate own-end features (2.9% of pool goals) were teaching the same ~0.98 pattern the xG model learned. Takes effect at the next xGOT retrain.

Reviews: both commits went through the Sonnet workflow review (finders + adversarial verify) — `1968b05` clean at low; `04e4185` at medium surfaced the NA-fallback gap, fixed pre-commit. xgot tests 37/37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NH8EoeH1goKW6ZohGQVVHY