### PR TITLE
dev -> main: psr-weekly OOM fix (snapshot stale 13 days) + P5-C step 1 versebus fetches + 07c checker fix

### DIFF
--- a/.github/workflows/psr-weekly-snapshot.yml
+++ b/.github/workflows/psr-weekly-snapshot.yml
@@ -58,38 +58,64 @@ jobs:
           needs: |
             devtools
 
-      - name: Download consolidated Opta data
-        env:
-          GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
+      # P5-C step 1 (versebus phase-5 plan): opta-latest fetches go through
+      # vb_download() — atomic rename, parquet magic-byte check, sha256 verify
+      # for manifest-committed assets, size check vs the asset listing
+      # otherwise. VERSEBUS_STRICT=1 is deliberately NOT set yet: opta-latest's
+      # bus_manifest.json currently commits only the daily scrape's own uploads
+      # (11 of ~127 assets) — opta_match_stats / opta_skills / opta_xmetrics
+      # are published by other pipelines via plain piggyback and strict mode
+      # would refuse them as uncommitted. Flip strict here only once those
+      # producers publish via vb_publish() (8b's own opta_psr_weekly upload
+      # already does).
+      # predictions-cache fetches (next step) stay on plain gh: that tag is
+      # heartbeat-mutated mid-run by opta-pipeline and is EXEMPT from strict.
+      - name: Download consolidated Opta data (versebus-verified)
         run: |
-          OPTA_DIR="${{ runner.temp }}/pannadata/opta"
-          mkdir -p "$OPTA_DIR"
-
-          echo "Downloading Opta files needed for PSR step 8b..."
-          for f in opta_player_stats.parquet opta_match_stats.parquet \
-                   opta_skills.parquet opta_xmetrics.parquet opta-catalog.json; do
-            if gh release download opta-latest --repo peteowen1/pannadata --pattern "$f" --dir "$OPTA_DIR" 2>/dev/null; then
-              echo "  Downloaded $f"
-            else
-              echo "  Skipped $f (not found)"
-            fi
-          done
+          cat > /tmp/vb_fetch_opta.R << 'EOF'
+          devtools::load_all()
+          opta_dir <- file.path(Sys.getenv("RUNNER_TEMP"), "pannadata", "opta")
+          dir.create(opta_dir, recursive = TRUE, showWarnings = FALSE)
+          repo <- "peteowen1/pannadata"; tag <- "opta-latest"
+          # Manifest fetch is best-effort in non-strict mode: a transient API
+          # error here must not kill the run before the per-file
+          # required/optional handling below — files still get size-verified
+          # against the asset listing without it (review catch).
+          manifest <- tryCatch(vb_read_manifest(repo, tag, required = FALSE),
+                               error = function(e) {
+            cli::cli_alert_warning("bus_manifest.json unavailable ({conditionMessage(e)}); proceeding without sha verification")
+            NULL
+          })
+          required <- c("opta_match_stats.parquet", "opta-catalog.json")
+          optional <- c("opta_player_stats.parquet", "opta_skills.parquet",
+                        "opta_xmetrics.parquet")
+          failed_required <- character(0)
+          for (f in c(required, optional)) {
+            ok <- tryCatch({
+              vb_download(repo, tag, f, file.path(opta_dir, f), manifest = manifest)
+              TRUE
+            }, vb_error = function(e) {
+              if (f %in% required) {
+                # Collect rather than stop: one run should surface EVERY
+                # broken asset, matching the old bash loop's diagnosability.
+                cli::cli_alert_danger("Required asset failed: {f} — {conditionMessage(e)}")
+                failed_required <<- c(failed_required, f)
+              } else {
+                cli::cli_alert_warning("Skipped {f}: {conditionMessage(e)}")
+              }
+              FALSE
+            })
+            if (ok) cli::cli_alert_success("Verified {f}")
+          }
+          if (length(failed_required) > 0) {
+            stop("Required asset(s) failed verification/download: ",
+                 paste(failed_required, collapse = ", "))
+          }
+          EOF
+          Rscript /tmp/vb_fetch_opta.R
 
           echo ""
-          ls -lh "$OPTA_DIR"
-
-          # Validate required files for step 8b
-          MISSING=0
-          for f in opta_match_stats.parquet opta-catalog.json; do
-            if [ ! -f "$OPTA_DIR/$f" ]; then
-              echo "FATAL: Required file $f was not downloaded"
-              MISSING=$((MISSING + 1))
-            fi
-          done
-          if [ "$MISSING" -gt 0 ]; then
-            echo "ERROR: $MISSING required file(s) missing. Cannot run PSR snapshot."
-            exit 1
-          fi
+          ls -lh "${{ runner.temp }}/pannadata/opta"
 
       - name: Download skills caches
         env:

--- a/R/opta_loaders.R
+++ b/R/opta_loaders.R
@@ -2172,6 +2172,24 @@ enrich_match_stats_with_xmetrics <- function(match_stats, verbose = TRUE,
   added_cols <- setdiff(names(xm), c("player_id", "match_id"))
   idx <- match(paste(match_stats$player_id, match_stats$match_id, sep = "\r"),
                paste(xm$player_id, xm$match_id, sep = "\r"))
+  # Join-coverage tripwire (review catch): unlike merge(), match() cannot
+  # hard-fail on key type/format drift — a structural divergence (e.g. after
+  # a bymatch regen changes id types) yields all-NA idx, and the NA->0 fill
+  # below would silently ship an xG-blind feature set that
+  # fail_if_missing_frac (which only tracks missing FILES) cannot see.
+  # Healthy coverage is ~98% (measured 2026-07-18).
+  matched_frac <- if (length(idx)) mean(!is.na(idx)) else 0
+  if (nrow(xm) > 0 && matched_frac == 0) {
+    stop("xMetrics join matched 0 of ", length(idx), " match_stats rows despite ",
+         nrow(xm), " xmetrics rows - player_id/match_id key mismatch ",
+         "(type or format drift after a bymatch regen?)", call. = FALSE)
+  }
+  if (nrow(xm) > 0 && matched_frac < 0.5) {
+    warning(sprintf(paste0(
+      "xMetrics join matched only %.1f%% of match_stats rows (healthy is ~98%%) - ",
+      "investigate key drift; unmatched rows get xMetrics = 0."),
+      100 * matched_frac), call. = FALSE)
+  }
   for (col in added_cols) {
     data.table::set(match_stats, j = col, value = xm[[col]][idx])
   }

--- a/R/opta_loaders.R
+++ b/R/opta_loaders.R
@@ -2065,10 +2065,28 @@ enrich_match_stats_with_xmetrics <- function(match_stats, verbose = TRUE,
     # gc()-invisible memory that OOM-killed the run well before its own
     # heavy lifting even started (panna#128). One query instead.
     if (verbose) cat("  Fetching consolidated xMetrics (remote, one query)...\n")
+    # Select ONLY the join keys + mapped columns at the duckdb layer: the
+    # consolidated bymatch parquet is ~3.3M rows x 70 columns, and the
+    # full-width load (plus the as.data.table() deep copy that followed it)
+    # was the transient that OOM-killed psr-weekly-snapshot on GHA on
+    # 2026-07-08/15 -- right on top of the ~6GB match_stats already resident.
+    # A narrow SELECT hard-fails on a vintage missing any named column
+    # (duckdb binder error), so fall back to the old full-width load there.
+    want <- c("player_id", "match_id", names(xm_map))
     xm <- tryCatch({
-      x <- data.table::as.data.table(
-        query_remote_opta_parquet("xmetrics_bymatch", opta_league = NULL, season = NULL))
-      keep <- intersect(c("player_id", "match_id", names(xm_map)), names(x))
+      x <- tryCatch(
+        query_remote_opta_parquet("xmetrics_bymatch", opta_league = NULL,
+                                  season = NULL, columns = want),
+        error = function(e) {
+          # Loud, not silent: if this fires every run (e.g. a renamed column
+          # made the narrow select permanently fail), the OOM-safety
+          # optimization has stopped working and logs must show it.
+          cli::cli_warn("Narrow xMetrics select failed ({conditionMessage(e)}); falling back to the full-width load (memory-heavy legacy path).")
+          query_remote_opta_parquet("xmetrics_bymatch", opta_league = NULL,
+                                    season = NULL)
+        })
+      data.table::setDT(x)
+      keep <- intersect(want, names(x))
       x[, ..keep]
     }, error = function(e) NULL)
     if (is.null(xm)) {

--- a/R/opta_loaders.R
+++ b/R/opta_loaders.R
@@ -2161,12 +2161,20 @@ enrich_match_stats_with_xmetrics <- function(match_stats, verbose = TRUE,
   old <- intersect(names(xm_map), names(xm))
   data.table::setnames(xm, old, unname(xm_map[old]))
   xm <- unique(xm, by = c("player_id", "match_id"))
-  # Join-assign by reference instead of merge(): merge() allocates a full
-  # copy of match_stats (+6GB on 08b's table — the second half of the
-  # 2026-07-08/15 psr-weekly OOM alongside the full-width remote load).
+  # Bounded-memory join instead of merge()/join-assign: merge() allocates a
+  # full copy of match_stats (+6GB on 08b's table), and even a data.table
+  # `X[i, (cols) := mget(...)]` join-assign transiently peaked at ~28.5GB on
+  # these key cardinalities (measured 2026-07-18, unkeyed character bmerge
+  # over 1.9M x 3.3M rows) — both OOM a 16GB GHA runner. A hash match() on
+  # composite keys + per-column set() peaks at ~7GB for the same result;
+  # unmatched rows get NA here and 0 in the fill loop below. \r cannot occur
+  # in Opta alphanumeric ids, so the pasted key is collision-free.
   added_cols <- setdiff(names(xm), c("player_id", "match_id"))
-  match_stats[xm, on = c("player_id", "match_id"),
-              (added_cols) := mget(paste0("i.", added_cols))]
+  idx <- match(paste(match_stats$player_id, match_stats$match_id, sep = "\r"),
+               paste(xm$player_id, xm$match_id, sep = "\r"))
+  for (col in added_cols) {
+    data.table::set(match_stats, j = col, value = xm[[col]][idx])
+  }
   added <- intersect(unname(xm_map), names(match_stats))
   for (col in added) {
     data.table::set(match_stats, which(is.na(match_stats[[col]])), col, 0)

--- a/R/opta_loaders.R
+++ b/R/opta_loaders.R
@@ -2021,14 +2021,24 @@ load_opta_xmetrics <- function(league, season = NULL, columns = NULL,
 #' @return \code{match_stats} (as data.table) with the xMetrics columns added
 #'   (NA-filled to 0 for player-matches with no shots). Returns input unchanged
 #'   (with a warning) if key columns are missing or no bymatch files are found
-#'   and \code{fail_if_missing_frac} is \code{Inf}.
+#'   and \code{fail_if_missing_frac} is \code{Inf}. NOTE: a data.table input
+#'   is enriched \emph{by reference} (no defensive copy — the copy alone was
+#'   ~6GB on 08b's table); always use the return value, and \code{copy()}
+#'   first if you need the un-enriched original.
 #' @family epv
 #' @export
 enrich_match_stats_with_xmetrics <- function(match_stats, verbose = TRUE,
                                               fail_if_missing_frac = Inf,
                                               source = c("local", "remote")) {
   source <- match.arg(source)
-  match_stats <- data.table::as.data.table(match_stats)
+  # as.data.table() on an already-valid data.table is a FULL deep copy (the
+  # panna#128 anti-pattern) — on 08b's ~6GB match_stats that copy alone was a
+  # third of the GHA runner. Guard it; a data.table input is enriched BY
+  # REFERENCE below (callers all reassign the return value, so this only
+  # drops the wasted copy).
+  if (!data.table::is.data.table(match_stats)) {
+    match_stats <- data.table::as.data.table(match_stats)
+  }
 
   # source xmetrics column -> match_stats column (suffix where names collide)
   xm_map <- c(
@@ -2151,7 +2161,12 @@ enrich_match_stats_with_xmetrics <- function(match_stats, verbose = TRUE,
   old <- intersect(names(xm_map), names(xm))
   data.table::setnames(xm, old, unname(xm_map[old]))
   xm <- unique(xm, by = c("player_id", "match_id"))
-  match_stats <- merge(match_stats, xm, by = c("player_id", "match_id"), all.x = TRUE)
+  # Join-assign by reference instead of merge(): merge() allocates a full
+  # copy of match_stats (+6GB on 08b's table — the second half of the
+  # 2026-07-08/15 psr-weekly OOM alongside the full-width remote load).
+  added_cols <- setdiff(names(xm), c("player_id", "match_id"))
+  match_stats[xm, on = c("player_id", "match_id"),
+              (added_cols) := mget(paste0("i.", added_cols))]
   added <- intersect(unname(xm_map), names(match_stats))
   for (col in added) {
     data.table::set(match_stats, which(is.na(match_stats[[col]])), col, 0)

--- a/data-raw/estimated-skills/07c_check_live_features.R
+++ b/data-raw/estimated-skills/07c_check_live_features.R
@@ -50,14 +50,22 @@ expected <- union(names(per90_map)[per90_map %in% derived], BLOCK_SUPPLIED)
 
 # --- 07c's transcribed list ----------------------------------------------------
 src <- readLines("data-raw/estimated-skills/07c_build_live_psv_constants.R", warn = FALSE)
-lst_start <- grep("^LIVE_OBSERVABLE_FEATURES <- c\\($", src)
-if (length(lst_start) != 1L) stop("could not locate LIVE_OBSERVABLE_FEATURES in 07c")
-lst_end <- lst_start + which(grepl("^\\)$", src[(lst_start + 1):length(src)]))[1]
-# eval() here is safe: it evaluates the c("...") literal from OUR OWN checked-in
+# eval() here is safe: it evaluates c("...") literals from OUR OWN checked-in
 # 07c script (same repo, same commit). The externally fetched stat-value.js is
 # only ever regex-parsed above, never evaluated.
-mine <- eval(parse(text = paste(sub("^LIVE_OBSERVABLE_FEATURES <- ", "",
-                                    paste(src[lst_start:lst_end], collapse = "\n")))))
+# LIVE_OBSERVABLE_FEATURES references LIVE_XMETRICS_FEATURES (7473e33), so
+# both assignments are extracted and evaluated in one environment — the old
+# single-assignment eval died with "object 'LIVE_XMETRICS_FEATURES' not found".
+lst_env <- new.env(parent = baseenv())
+.eval_07c_assign <- function(name) {
+  a_start <- grep(sprintf("^%s <- c\\($", name), src)
+  if (length(a_start) != 1L) stop(sprintf("could not locate %s in 07c", name))
+  a_end <- a_start + which(grepl("^\\)$", src[(a_start + 1):length(src)]))[1]
+  eval(parse(text = paste(src[a_start:a_end], collapse = "\n")), envir = lst_env)
+}
+.eval_07c_assign("LIVE_XMETRICS_FEATURES")
+.eval_07c_assign("LIVE_OBSERVABLE_FEATURES")
+mine <- lst_env$LIVE_OBSERVABLE_FEATURES
 
 # --- Compare, restricted to features that carry coefficients -------------------
 all_coef_stats <- unique(unlist(lapply(

--- a/man/enrich_match_stats_with_xmetrics.Rd
+++ b/man/enrich_match_stats_with_xmetrics.Rd
@@ -36,7 +36,10 @@ per-league/season tree; see \code{\link{load_opta_xmetrics}}).}
 \code{match_stats} (as data.table) with the xMetrics columns added
 (NA-filled to 0 for player-matches with no shots). Returns input unchanged
 (with a warning) if key columns are missing or no bymatch files are found
-and \code{fail_if_missing_frac} is \code{Inf}.
+and \code{fail_if_missing_frac} is \code{Inf}. NOTE: a data.table input
+is enriched \emph{by reference} (no defensive copy — the copy alone was
+~6GB on 08b's table); always use the return value, and \code{copy()}
+first if you need the un-enriched original.
 }
 \description{
 Left-joins per-player-match xG and the redesign's over-performance features

--- a/tests/testthat/test-opta-loaders.R
+++ b/tests/testthat/test-opta-loaders.R
@@ -411,3 +411,45 @@ test_that("remote xMetrics enrichment narrow-selects, falling back full-width on
   expect_null(seen_cols[[2]])                        # fallback is full-width
   expect_equal(out$xg_per90, 0.5)                    # join still lands
 })
+
+test_that("remote xMetrics enrichment aligns a multi-row match() join (shuffled, partial)", {
+  # The hash-match join replaced merge() (OOM fix); a 1x1 case can't catch
+  # misalignment, so exercise unmatched rows + xm in a different row order.
+  ms <- data.frame(
+    player_id = c("p1", "p2", "p1"), player_name = "P",
+    match_id  = c("m1", "m1", "m2"),
+    league = "EPL", season = "2024-2025",
+    goals_p90 = 1, stringsAsFactors = FALSE
+  )
+  xm_remote <- data.frame(
+    player_id = c("p2", "p1"), match_id = c("m1", "m2"),
+    xg_per90 = c(0.7, 0.9), gsaa_per90 = c(NA_real_, 0.2),
+    stringsAsFactors = FALSE
+  )
+  testthat::local_mocked_bindings(
+    query_remote_opta_parquet = function(...) xm_remote
+  )
+  out <- enrich_match_stats_with_xmetrics(ms, verbose = FALSE, source = "remote")
+  expect_equal(out$xg_per90, c(0, 0.7, 0.9))   # row 1 unmatched -> 0; rows realigned
+  expect_equal(out$gsaa_per90, c(0, 0, 0.2))   # NA inside a matched row -> 0 too
+})
+
+test_that("remote xMetrics enrichment errors when the join matches zero rows", {
+  ms <- data.frame(
+    player_id = "p1", player_name = "P", match_id = "m1",
+    league = "EPL", season = "2024-2025",
+    goals_p90 = 1, stringsAsFactors = FALSE
+  )
+  # Key drift: xmetrics rows exist but share no (player_id, match_id) values.
+  xm_remote <- data.frame(
+    player_id = "999", match_id = "888", xg_per90 = 0.5,
+    stringsAsFactors = FALSE
+  )
+  testthat::local_mocked_bindings(
+    query_remote_opta_parquet = function(...) xm_remote
+  )
+  expect_error(
+    enrich_match_stats_with_xmetrics(ms, verbose = FALSE, source = "remote"),
+    "matched 0 of"
+  )
+})

--- a/tests/testthat/test-opta-loaders.R
+++ b/tests/testthat/test-opta-loaders.R
@@ -384,3 +384,30 @@ test_that("enrich_match_stats_with_xmetrics surfaces gaps and fail-fasts", {
     enrich_match_stats_with_xmetrics(ms, verbose = FALSE))
   expect_false("xg_per90" %in% names(out2))
 })
+
+test_that("remote xMetrics enrichment narrow-selects, falling back full-width on old vintages", {
+  ms <- data.frame(
+    player_id = "p1", player_name = "P", match_id = "m1",
+    league = "EPL", season = "2024-2025",
+    goals_p90 = 1, stringsAsFactors = FALSE
+  )
+  seen_cols <- list()
+  testthat::local_mocked_bindings(
+    query_remote_opta_parquet = function(table_type, opta_league, season = NULL,
+                                         columns = NULL, ...) {
+      seen_cols <<- c(seen_cols, list(columns))  # [[<- NULL would delete, not append
+      # Old-vintage parquet: a narrow SELECT naming a missing column binder-errors.
+      if (!is.null(columns)) stop("Binder Error: column \"gsaa_per90\" not found")
+      data.frame(player_id = "p1", match_id = "m1", xg_per90 = 0.5,
+                 stringsAsFactors = FALSE)
+    }
+  )
+  expect_warning(
+    out <- enrich_match_stats_with_xmetrics(ms, verbose = FALSE, source = "remote"),
+    "falling back to the full-width load"
+  )
+  expect_length(seen_cols, 2L)                       # narrow attempt, then fallback
+  expect_true(all(c("player_id", "match_id", "gsaa_per90") %in% seen_cols[[1]]))
+  expect_null(seen_cols[[2]])                        # fallback is full-width
+  expect_equal(out$xg_per90, 0.5)                    # join still lands
+})


### PR DESCRIPTION
**Merge before Wednesday Jul-22 10:00 UTC** — the psr-weekly cron currently OOMs on main (failed Jul 8 + Jul 15; `opta_psr_weekly.parquet` was stale since Jul 5 until today's dev-verified run republished it).

## psr-weekly OOM — root cause was three stacked allocations (5 commits)

`enrich_match_stats_with_xmetrics(source="remote")`, phase-measured locally with `gc(reset=TRUE)` peaks:
1. **Full-width remote load**: 3.3M×70 consolidated bymatch via duckdb with no column selection → now a 16-column SELECT (full-width fallback for old vintages, warned loudly).
2. **`as.data.table()` deep copy** of the ~6GB match_stats (the #128 anti-pattern, still live here) → copy-guarded.
3. **The surprise**: even a by-reference data.table join-assign transiently peaks **~28.5GB** (unkeyed character bmerge over 1.9M×3.3M keys) → replaced with a hash `match()` on composite keys + per-column `set()`, **~7GB peak measured**, 98.6% join coverage.

Notable: 8b had *never* actually enriched on GHA — every prior green was the warn-only xG-blind path (the enrichment failed fast until the consolidated bymatch file became loadable ~Jul 7, which is why Jul 8 was the first OOM). Verification run [29629866127](https://github.com/peteowen1/panna/actions/runs/29629866127): 8b SUCCESS, peak RSS 9.8GB, `opta_psr_weekly.parquet` uploaded (197MB, 237 dates, manifest-committed via vb_publish) — **first GHA PSR snapshot with real gsaa/WOE features**.

Safety nets added per review: join-coverage tripwire (stop at 0% match, warn <50% — `match()` can't hard-fail on key type drift the way `merge()` did), loud fallback warning, multi-row alignment + zero-coverage tests. By-reference enrichment contract documented in the roxygen.

## P5-C step 1 (phase-5 plan)

`psr-weekly-snapshot.yml`'s opta-latest fetches: bash `gh release download` loop → `vb_download()` (atomic rename, parquet magic bytes, sha256 where manifest-committed, size-check otherwise; manifest fetched once, best-effort; required-asset failures aggregate). **`VERSEBUS_STRICT=1` deliberately NOT flipped** — opta-latest's manifest commits only the daily scrape's 11/~127 assets; gate documented in-workflow and in docs/DECISIONS.md.

## 07c lockstep checker crash (affects main's cron today)

`7473e33` (already on main) split `LIVE_XMETRICS_FEATURES` out of `LIVE_OBSERVABLE_FEATURES`; the checker's single-assignment eval dies with "object not found". Fixed to eval both in one sandbox env. With the crash gone the checker surfaces **real drift** → #153 (resolve with #147 post-final). Until then the cron goes red at the lockstep step *by design* — the 8b snapshot uploads before it, so PSR freshness is unaffected.

## Reviews / tests
Four Sonnet workflow reviews across the session (per-commit + final whole-diff pass at medium): all confirmed findings fixed pre-commit or explicitly declined with rationale in the commit log. opta-loaders 62/62, xgot 37/37 locally; four dev verification dispatches document the fix progression (29628889193 → 29629866127).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NH8EoeH1goKW6ZohGQVVHY