### PR TITLE
Bounded retry on corrupt remote-parquet reads (#157)

### DIFF
--- a/R/opta_loaders.R
+++ b/R/opta_loaders.R
@@ -1667,7 +1667,9 @@ list_opta_leagues <- function(type = NULL, tier = NULL,
 query_remote_opta_parquet <- function(table_type, opta_league, season = NULL,
                                        columns = NULL,
                                        repo = "peteowen1/pannadata",
-                                       tag = "opta-latest") {
+                                       tag = "opta-latest",
+                                       max_retries = 2L,
+                                       retry_backoff_sec = 30) {
 
   # match_events are stored as per-league files (too large for single consolidated file)
   if (table_type == "match_events") {
@@ -1675,6 +1677,34 @@ query_remote_opta_parquet <- function(table_type, opta_league, season = NULL,
                                            repo = repo, tag = tag))
   }
 
+  # panna#157: a same-second daily dispatch can have another producer
+  # mid-overwrite (plain piggyback delete-then-upload, non-atomic) on this
+  # exact asset while we're downloading/querying it -- the corrupt-file
+  # detection below already exists, but previously just aborted instead of
+  # retrying. Bounded retry turns a same-run transient race into a ~30-90s
+  # delay instead of a failed/degraded pipeline step; a non-corruption error
+  # (missing file, bad SQL, network outage) still fails immediately.
+  attempt <- 0L
+  repeat {
+    attempt <- attempt + 1L
+    out <- tryCatch(
+      .query_remote_opta_parquet_once(table_type, opta_league, season, columns, repo, tag),
+      error = function(e) e
+    )
+    if (!inherits(out, "error")) return(out)
+    is_corruption <- grepl("corrupt|magic bytes", conditionMessage(out), ignore.case = TRUE)
+    if (!is_corruption || attempt > max_retries) stop(out)
+    cli::cli_alert_warning(paste0(
+      "Retry {attempt}/{max_retries} for {table_type} after a corrupt/incomplete read ",
+      "(likely a concurrent overwrite on {repo}@{tag}) -- waiting {retry_backoff_sec}s."
+    ))
+    Sys.sleep(retry_backoff_sec)
+  }
+}
+
+#' @keywords internal
+.query_remote_opta_parquet_once <- function(table_type, opta_league, season,
+                                             columns, repo, tag) {
   if (!requireNamespace("piggyback", quietly = TRUE)) {
     cli::cli_abort("Package 'piggyback' is required for remote Opta loading.")
   }

--- a/man/query_remote_opta_parquet.Rd
+++ b/man/query_remote_opta_parquet.Rd
@@ -10,7 +10,9 @@ query_remote_opta_parquet(
   season = NULL,
   columns = NULL,
   repo = "peteowen1/pannadata",
-  tag = "opta-latest"
+  tag = "opta-latest",
+  max_retries = 2L,
+  retry_backoff_sec = 30
 )
 }
 \arguments{

--- a/tests/testthat/test-query-remote-opta-retry.R
+++ b/tests/testthat/test-query-remote-opta-retry.R
@@ -1,0 +1,61 @@
+# panna#157: query_remote_opta_parquet() retries a bounded number of times on
+# a corrupt/incomplete read (the daily epv/predictions concurrent-write race
+# on opta_xmetrics_bymatch.parquet) instead of aborting immediately.
+
+test_that("retries once on a corrupt-file error, then succeeds", {
+  call_count <- 0L
+  local_mocked_bindings(
+    .query_remote_opta_parquet_once = function(...) {
+      call_count <<- call_count + 1L
+      if (call_count == 1L) {
+        cli::cli_abort("Cached parquet file is corrupt (no magic bytes).")
+      }
+      data.frame(x = 1)
+    }
+  )
+  result <- query_remote_opta_parquet("player_stats", "ENG",
+                                       retry_backoff_sec = 0)
+  expect_equal(call_count, 2L)
+  expect_equal(result, data.frame(x = 1))
+})
+
+test_that("gives up after max_retries and rethrows the corruption error", {
+  call_count <- 0L
+  local_mocked_bindings(
+    .query_remote_opta_parquet_once = function(...) {
+      call_count <<- call_count + 1L
+      cli::cli_abort("Downloaded opta_shots.parquet is corrupt (incomplete download).")
+    }
+  )
+  expect_error(
+    query_remote_opta_parquet("shots", "ENG", max_retries = 2L,
+                               retry_backoff_sec = 0),
+    "corrupt"
+  )
+  expect_equal(call_count, 3L)  # first attempt + 2 retries
+})
+
+test_that("does NOT retry on a non-corruption error", {
+  call_count <- 0L
+  local_mocked_bindings(
+    .query_remote_opta_parquet_once = function(...) {
+      call_count <<- call_count + 1L
+      cli::cli_abort("Package 'piggyback' is required for remote Opta loading.")
+    }
+  )
+  expect_error(
+    query_remote_opta_parquet("fixtures", "ENG", retry_backoff_sec = 0),
+    "piggyback"
+  )
+  expect_equal(call_count, 1L)
+})
+
+test_that("match_events dispatches to query_remote_opta_match_events without retry wrapping", {
+  local_mocked_bindings(
+    query_remote_opta_match_events = function(...) "match_events_result"
+  )
+  expect_equal(
+    query_remote_opta_parquet("match_events", "ENG"),
+    "match_events_result"
+  )
+})


### PR DESCRIPTION
## Summary
- `query_remote_opta_parquet()` now retries (bounded, default 2 attempts, 30s backoff) when the download or DuckDB query fails with a corruption-class error, instead of aborting immediately. Addresses panna#157's option 3 ("probably the right first move") — the daily epv-pipeline (04b) and predictions-pipeline (10b) fire on the same dispatch and can race on `opta_xmetrics_bymatch.parquet`'s non-atomic overwrite.
- Non-corruption errors (missing file, bad SQL, genuine network outage) still fail immediately — no wasted retries.
- 4 new tests (mocked via `local_mocked_bindings`) cover: retry-then-succeed, exhaust-retries-and-rethrow, no-retry-on-non-corruption-error, and match_events dispatch bypassing the retry wrapper entirely.

## Test plan
- New test file green, plus the existing `opta-loaders` suite unaffected.
- CI on this PR is the pre-merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfQepfp98Mvj2Auk2jwZiG