### PR TITLE
panna#178: dated predictions.parquet snapshot step + recent shot-data fixes

### DIFF
--- a/.github/workflows/predictions-pipeline.yml
+++ b/.github/workflows/predictions-pipeline.yml
@@ -222,6 +222,12 @@ jobs:
               step_05_fit_goals_model        = TRUE,
               step_06_fit_outcome_model      = TRUE,
               step_07_predict_fixtures       = TRUE,
+              # Archive a dated predictions.parquet snapshot to the
+              # predictions-history release (panna#178) so a future as-at
+              # replay of a club league/cup can use the ACTUAL predictions
+              # that existed on a given historical date, same pattern as
+              # 12b/12c below for WC2026 minutes/team-strength.
+              step_07b_snapshot_predictions  = TRUE,
               step_08_evaluate_model         = TRUE,
               step_09_upload_predictions     = TRUE,
               step_10_export_blog_data       = TRUE,

--- a/OPTA_REFERENCE.md
+++ b/OPTA_REFERENCE.md
@@ -132,6 +132,21 @@ and a follow-up question: can a blocked shot's real location be recovered at all
   here as a recoverable signal for anyone who later wants a "how save-like was this block"
   feature elsewhere (e.g. EPV credit, a defensive-blocking rating).
 
+### Confirmed — empirically, 2026-07-23 (panna#175 / inthegame-blog#489)
+
+- **231** | **Goal-mouth y for Miss shots specifically** | q102 (goal-mouth y) is reliable for
+  on-target-ish shots (Post/Saved/Goal) but scatters far outside the goal frame for genuine
+  misses (median offset ~9 units vs the confirmed on-target range). q231 validated via a natural
+  experiment: Post-hit shots (type 14) MUST cross the line at the known post positions
+  (45.2/54.8) — sampled q231 values landed almost exactly there (45.0, 55.0). Confirmed at
+  production scale: on 3.27M shots, q231 for Miss shots has median=50.0, 1-99% range
+  43.8-56.1 (std 2.5) — tightly inside the frame, vs q102's own median=50.2, 1-99% range
+  2.2-98.3 (std 14.1) for the same population. `pannadata`'s scraper + `backfill_goalmouth.py`
+  now source Miss-shot `goalmouth_y` from q231 (falling back to q102 when q231 is absent, ~13-30%
+  of misses). **No working z/height (q103) replacement exists for misses** — q230 correlates
+  -0.33 with shot distance (a confidence/tracking-quality signature, not a coordinate), q147 is
+  too sparse (~13.5% presence) to rely on. That half remains genuinely open.
+
 ### Unconfirmed — do not guess, do the work first
 
 - **Six-yard block** (`sixYardBlock`): no qualifier found that discriminates it from a plain
@@ -154,10 +169,11 @@ and a follow-up question: can a blocked shot's real location be recovered at all
   (marked "implied", i.e. never actually checked); other code in this ecosystem has used both
   36 and 72 for foot-side at different points. Don't trust any of these without a dedicated
   empirical check the same way the four qualifiers above were confirmed.
-- **Zone/coordinate qualifiers 55/56/102/103/230/231**: the prior version of this doc listed
+- **Zone/coordinate qualifiers 55/56/102/103/230**: the prior version of this doc listed
   these as start/end coordinate qualifiers, but they conflict with 140/141 (confirmed above,
   and the qualifiers actually consumed by production code for end coordinates). Not re-verified
-  this session — treat the prior claims here as unverified, not wrong-but-unconfirmed.
+  this session — treat the prior claims here as unverified, not wrong-but-unconfirmed. (231's
+  specific role as a Miss-shot goal-mouth y-coordinate IS now confirmed — see above.)
 
 ### Outcome Field
 

--- a/OPTA_REFERENCE.md
+++ b/OPTA_REFERENCE.md
@@ -95,6 +95,43 @@ for a matched negative sample. Full population, not a subsample, unless noted.
 | **168** | **Flick on** | On type 1/44 events: 100% of 60 sampled `totalFlickOn`-positive players, 0% of 104 negative. |
 | **75** | **Won corners** (moderate confidence) | On type-6 (Corner Awarded) events: 57% of 3383 `wonCorners`-positive players vs 4.6% of 2805 negatives — a real ~12x lift, but not a clean 100/0 split like the three above. Likely correct qualifier but attribution (who exactly gets the row) may need refinement before treating this as fully nailed down; don't ship a derivation off this without a tighter re-check. |
 
+### Confirmed — empirically, 2026-07-23 (panna#176)
+
+Method: EPL 2021-22 → 2025-26 `opta_shot_events.parquet` joined to `events_EPL.parquet` on
+`(match_id, event_id)`, `type_id==15` ("Attempt Saved") shots cross-referenced against raw
+`qualifier_json`. Investigation prompted by the xGOT blocked-shot contamination fix (panna#176)
+and a follow-up question: can a blocked shot's real location be recovered at all, given its own
+`goalmouth_y`/`goalmouth_z` (q102/103) is a meaningless placeholder (see `backfill_goalmouth.py`)?
+
+- **q82 ("Blocked shot") has been flat and stable since at least 2011-12** — ~53-58% of every
+  EPL season's `type_id==15` shots carry it, no trend, no step change. What DID change, starting
+  mid-2019-20 and complete by 2020-21, is that Opta's feed switched from omitting q102/103
+  entirely for a blocked shot (true NA — pre-2020 goalmouth coverage of ~45-48% tracks almost
+  exactly the non-blocked share) to always filling a value, including a meaningless placeholder
+  (`goalmouth_z==19`, the frame-height midpoint) for shots that structurally have nothing to
+  report. Full season-by-season table in `backfill_goalmouth.py`'s docstring.
+- **A blocked shot's REAL location IS recoverable — from a companion event, not the shot itself.**
+  Every blocked shot is immediately followed (within the next 1-3 events, in raw event order) by
+  a separate `type_id==10` ("Save") event, credited to the DEFENDING team, carrying **q94**
+  ("Outfielder block", confirmed above) — this is Opta crediting the specific defender who made
+  the block, distinct from the shooter's own "Attempt Saved" row. That companion event's `x`/`y`
+  are REAL coordinates (not a placeholder). Across every EPL 2024-25 blocked shot: the companion
+  `Save`+q94 event is findable 75.7% of the time (n=2,201/2,907; the rest are scrambles/rebounds
+  where a second shot or corner intervenes before the Save event). Its `x` has genuine spread —
+  median 11.4, IQR 7.6-15.4, range 0.1-40.6 — NOT a degenerate constant. 13.0% sit at `x<=6`
+  (effectively a last-ditch, goal-line/"basically a save" block); 63% fall in the 5-20 range
+  (a real defensive intervention inside/around the box); the remaining 26% extend to x=20-40
+  (blocks further out, in the run of play).
+- **This refines, but does not resolve, the "Six-yard block" item below.** That earlier
+  investigation checked `type_id==12` (Clearance) events matched to the `sixYardBlock` STAT name
+  specifically and found no location signal there. This finding is a DIFFERENT, more directly
+  useful population — the `type_id==10`+q94 event Opta logs as the direct counterpart to a
+  blocked SHOT — and it does carry a real signal. Not (yet) wired into any panna code; xGOT
+  still correctly excludes ALL blocked shots regardless of block distance (the shot itself never
+  reached the goal frame, so xGOT has nothing to score there either way) — this is documented
+  here as a recoverable signal for anyone who later wants a "how save-like was this block"
+  feature elsewhere (e.g. EPV credit, a defensive-blocking rating).
+
 ### Unconfirmed — do not guess, do the work first
 
 - **Six-yard block** (`sixYardBlock`): no qualifier found that discriminates it from a plain
@@ -103,6 +140,15 @@ for a matched negative sample. Full population, not a subsample, unless noted.
   events at x≈13.8 — clearance-off-line events, by contrast, are cleanly separated at x≈4.9).
   Whatever marks this stat, it isn't in the qualifier set checked here. Needs either a wider
   qualifier search or a different signal entirely (a paired event? a distinct sub-type of q94?).
+  See the 2026-07-23 entry above for a related-but-distinct finding: the `sixYardBlock` STAT
+  name specifically remains unresolved, but a blocked SHOT's real block location is recoverable
+  via its companion `type_id==10`+q94 event's own x/y.
+- **q14 ("Last man") does not travel to domestic-league data.** Re-checked 2026-07-23 on EPL:
+  q14 has 0% presence on `type_id==12` (Clearance) events across all 15 seasons (2011-12 →
+  2025-26), confirmed via a raw qualifier-key dump on 2,000 sampled events (14 simply isn't in
+  the key set: `{15,21,56,138,140,141,167,178,185,189,212,213,233,388,389,397}`). The
+  `clearanceOffLine` finding above was confirmed on World Cup data only — treat it as
+  competition-scoped, not general, until re-checked on another domestic league.
 - **Left foot / right foot split**: q15=Head is solid (re-confirmed above), but the foot-side
   IDs are contested across sources — the prior version of this doc claimed 73=left foot
   (marked "implied", i.e. never actually checked); other code in this ecosystem has used both

--- a/R/xgot_model.R
+++ b/R/xgot_model.R
@@ -93,6 +93,10 @@ XGOT_ON_TARGET_TYPE_IDS <- c(15L, 16L)
 #'
 #' @param shot_events Data frame from load_opta_shot_events(); must include
 #'   goalmouth_y / goalmouth_z (run pannadata backfill_goalmouth.py first).
+#'   Should also include is_blocked (run pannadata
+#'   backfill_blocked_shots.py) to exclude blocked shots from on-target;
+#'   without it, blocked shots remain in training with placeholder
+#'   goalmouth coords (panna#176).
 #' @param min_season_end_year Earliest season end-year to keep (default 2021).
 #' @return Data frame of features + target is_goal, ready for fit_xgot_model().
 #' @keywords internal
@@ -111,8 +115,23 @@ prepare_shots_for_xgot <- function(shot_events,
     ))
   }
 
-  # On-target only.
+  # On-target only. type_id==15 ("Attempt Saved") is an umbrella Opta uses
+  # for BOTH real keeper saves and shots blocked by an outfield defender
+  # before reaching the goal frame -- a blocked shot never crosses the
+  # goal-line plane, so its goalmouth_y/z is a placeholder (typically the
+  # frame-height midpoint, ~98% of blocked shots land on goalmouth_z==19),
+  # not a real crossing point. Matches OPTA_REFERENCE.md's on-target
+  # formula: (type 15 & !q82) | type 16 (panna#176).
   on_target <- shot_events$type_id %in% XGOT_ON_TARGET_TYPE_IDS
+  if ("is_blocked" %in% names(shot_events)) {
+    is_blocked <- shot_events$is_blocked %in% TRUE
+    if (any(on_target & is_blocked)) {
+      cli::cli_alert_info("Excluding {sum(on_target & is_blocked)} blocked shot{?s} (q82) from xGOT on-target population.")
+    }
+    on_target <- on_target & !is_blocked
+  } else {
+    cli::cli_warn("shot_events lacks is_blocked -- blocked shots (Attempt Saved with q82) will remain in training with placeholder goalmouth coords; re-sync opta_shot_events.parquet for qualifier-based exclusion.")
+  }
   shot_events <- shot_events[on_target, , drop = FALSE]
 
   # Drop own goals from TRAINING: they enter as guaranteed-goal rows with
@@ -317,10 +336,13 @@ predict_xgot <- function(xgot_model, shot_features) {
 #' @param xgot_model Fitted xGOT model.
 #' @param goalmouth_lookup Data frame keyed by (\code{match_id},
 #'   \code{event_id}) with \code{type_id}, \code{goalmouth_y},
-#'   \code{goalmouth_z}, and \code{situation} for shot events - e.g. from
-#'   match_events / opta_shot_events. \code{situation} is required to avoid
-#'   train/serve skew (the model trained on real situations); without it,
-#'   set-piece/corner/free-kick shots are scored as open-play.
+#'   \code{goalmouth_z}, \code{situation}, and \code{is_blocked} for shot
+#'   events - e.g. from match_events / opta_shot_events. \code{situation} is
+#'   required to avoid train/serve skew (the model trained on real
+#'   situations); without it, set-piece/corner/free-kick shots are scored as
+#'   open-play. \code{is_blocked} excludes shots blocked by an outfield
+#'   defender (q82) from on-target, matching training (panna#176); without
+#'   it, blocked shots are scored as real on-target attempts.
 #' @return SPADL actions with an \code{xgot} column added.
 #' @keywords internal
 add_xgot_to_spadl <- function(spadl_actions, xgot_model, goalmouth_lookup) {
@@ -347,8 +369,13 @@ add_xgot_to_spadl <- function(spadl_actions, xgot_model, goalmouth_lookup) {
   if (!have_situation) {
     cli::cli_warn("goalmouth_lookup lacks `situation` - set-piece shots will be scored as open-play (train/serve skew).")
   }
+  have_is_blocked <- "is_blocked" %in% names(goalmouth_lookup)
+  if (!have_is_blocked) {
+    cli::cli_warn("goalmouth_lookup lacks `is_blocked` - blocked shots (Attempt Saved with q82) will be scored as real on-target attempts (train/serve skew, panna#176).")
+  }
   lk_cols <- c("match_id", "event_id", "type_id", "goalmouth_y", "goalmouth_z",
-               if (have_situation) "situation")
+               if (have_situation) "situation",
+               if (have_is_blocked) "is_blocked")
   lk <- goalmouth_lookup[, lk_cols, drop = FALSE]
   # De-dup on the join key: a duplicated (match_id, event_id) would let merge()
   # inflate rows and misalign coords to the wrong shot (silent wrong xGOT).
@@ -366,6 +393,12 @@ add_xgot_to_spadl <- function(spadl_actions, xgot_model, goalmouth_lookup) {
   # FALSE, which would mislabel it off-target (xgot=0) instead of unknown (NA).
   on_target <- ifelse(is.na(joined$type_id), NA,
                       joined$type_id %in% XGOT_ON_TARGET_TYPE_IDS)
+  # Blocked shots (q82) never crossed the goal-line plane -- exclude them the
+  # same way training does (panna#176). Matches OPTA_REFERENCE.md's on-target
+  # formula: (type 15 & !q82) | type 16.
+  if (have_is_blocked) {
+    on_target <- on_target & !(joined$is_blocked %in% TRUE)
+  }
   has_gm <- !is.na(joined$goalmouth_y) & !is.na(joined$goalmouth_z)
   predable <- on_target & has_gm
   predable[is.na(predable)] <- FALSE
@@ -411,7 +444,7 @@ add_xgot_to_spadl <- function(spadl_actions, xgot_model, goalmouth_lookup) {
   xgot_vec[is_og] <- NA_real_
 
   spadl_actions$xgot[shot_idx] <- xgot_vec
-  spadl_actions$shot_on_target[shot_idx] <- on_target  # TRUE/FALSE/NA per raw type_id
+  spadl_actions$shot_on_target[shot_idx] <- on_target  # TRUE/FALSE/NA per type_id, blocked shots excluded (panna#176)
   n_pred <- sum(predable)
   n_na_ot <- sum(on_target & !has_gm, na.rm = TRUE)
   cli::cli_alert_success(

--- a/data-raw/match-predictions-opta/07b_snapshot_predictions.R
+++ b/data-raw/match-predictions-opta/07b_snapshot_predictions.R
@@ -1,0 +1,79 @@
+# 07b_snapshot_predictions.R
+# Archive a DATED snapshot of predictions.parquet, so a future as-at replay of
+# a club league/cup can use the ACTUAL predictions that existed on a given
+# historical date, rather than today's current model re-stamped onto a past
+# date (panna#178 — same "exact-replay fidelity" gap the WC2026 snapshot
+# steps, 12b/12c, close for minutes/team-strength).
+#
+# Why this exists: step 13 publishes predictions.parquet to predictions-latest,
+# which is CLOBBERED every run — only the latest survives, so there is no
+# history to replay against. This step writes predictions_<DATE>.parquet to a
+# SEPARATE release tag (predictions-history) that nothing clobbers and the
+# blog's normal R2 sync ignores. Each run a new dated file accumulates.
+#
+# Deliberately no diff output here (unlike 12b/12c) — predictions.parquet
+# already carries per-match rows for every league/date, so there's no single
+# natural join key to diff on across dates the way team/minutes tables have;
+# the raw dated snapshots are the deliverable the as-at replay consumes.
+#
+# predictions.parquet is FINAL at step 7 (nothing downstream mutates it), so
+# snapshotting the step-7 cache file here captures the authoritative value.
+#
+# Idempotent within a day (--clobber). Sourced with local = TRUE from
+# run_predictions_opta.R, so the body is wrapped in a function.
+
+suppressPackageStartupMessages({ library(arrow) })
+
+.snapshot_predictions <- function() {
+  cache_dir <- if (exists("cache_dir", inherits = TRUE)) {
+    get("cache_dir", inherits = TRUE)
+  } else file.path("data-raw", "cache-predictions-opta")
+  repo <- "peteowen1/pannadata"
+  tag  <- "predictions-history"
+
+  src_path <- file.path(cache_dir, "predictions.parquet")
+  if (!file.exists(src_path)) {
+    message("  predictions.parquet not in cache — run step 07 first; skipping snapshot")
+    return(invisible(NULL))
+  }
+
+  today      <- Sys.Date()
+  snap_name  <- sprintf("predictions_%s.parquet", today)
+  snap_local <- file.path(cache_dir, snap_name)
+  file.copy(src_path, snap_local, overwrite = TRUE)
+
+  curr_n <- nrow(read_parquet(src_path))
+  message(sprintf("  Snapshot written: %s (%d rows)", snap_name, curr_n))
+
+  no_upload <- isTRUE(Sys.getenv("WC2026_NO_UPLOAD", "") == "1")
+  gh_ok <- !is.null(tryCatch(system2("gh", "--version", stdout = TRUE, stderr = TRUE),
+                             error = function(e) NULL))
+  gh_run <- function(args) system2("gh", args, stdout = TRUE, stderr = TRUE)
+  gh_failed <- function(res) !is.null(attr(res, "status")) && attr(res, "status") != 0
+
+  if (gh_ok && !no_upload) {
+    rel <- gh_run(c("release", "view", tag, "--repo", repo))
+    if (gh_failed(rel)) {
+      crt <- gh_run(c("release", "create", tag, "--repo", repo,
+               "--title", shQuote("Match Predictions History"),
+               "--notes", shQuote("Dated snapshots of predictions.parquet for as-at replay fidelity (panna#178).")))
+      if (gh_failed(crt))
+        warning("Failed to create the ", tag, " release: ", paste(crt, collapse = "\n"),
+                call. = FALSE, immediate. = TRUE)
+    }
+    res <- gh_run(c("release", "upload", tag, shQuote(snap_local), "--repo", repo, "--clobber"))
+    if (gh_failed(res)) {
+      warning(sprintf("Failed to upload %s: %s", basename(snap_local), paste(res, collapse = "\n")),
+              call. = FALSE, immediate. = TRUE)
+    } else {
+      message(sprintf("  Uploaded %s", basename(snap_local)))
+    }
+  } else {
+    message("  Skipped upload (gh unavailable or WC2026_NO_UPLOAD=1).")
+  }
+
+  message("\n=== Predictions snapshot complete ===")
+  invisible(NULL)
+}
+
+.snapshot_predictions()

--- a/data-raw/match-predictions-opta/run_predictions_opta.R
+++ b/data-raw/match-predictions-opta/run_predictions_opta.R
@@ -56,6 +56,7 @@ if (!exists("run_steps", inherits = FALSE)) {
     step_05_fit_goals_model          = TRUE,
     step_06_fit_outcome_model        = TRUE,
     step_07_predict_fixtures         = TRUE,
+    step_07b_snapshot_predictions    = FALSE,  # Opt-in: archive dated predictions.parquet snapshot (panna#178)
     step_08_evaluate_model           = TRUE,
     step_09_upload_predictions       = FALSE,  # Opt-in: upload to GitHub
     step_10_export_blog_data         = FALSE,  # Opt-in: export blog parquets
@@ -269,6 +270,15 @@ check_pred_critical(step_results[[6]])
 
 step_results[[7]] <- run_pipeline_step("predict_fixtures", 7, function() {
   source("data-raw/match-predictions-opta/07_predict_fixtures.R", local = TRUE)
+})
+
+# 11b. Step 7b: Snapshot Predictions ----
+# Archive a dated copy of predictions.parquet to the predictions-history
+# release (panna#178). Runs after step 7, which writes the cache file this
+# reads.
+
+step_results[["7b"]] <- run_pipeline_step("snapshot_predictions", "7b", function() {
+  source("data-raw/match-predictions-opta/07b_snapshot_predictions.R", local = TRUE)
 })
 
 # 12. Step 8: Evaluate Model ----

--- a/tests/testthat/test-xgot-model.R
+++ b/tests/testthat/test-xgot-model.R
@@ -52,6 +52,23 @@ test_that("prepare_shots_for_xgot drops own goals (type-16 goal at own end) from
   expect_true(all(c("gm_y", "dist_to_near_post", "is_goal") %in% names(feat)))
 })
 
+test_that("prepare_shots_for_xgot excludes blocked shots (q82) from training (#176)", {
+  shots <- data.frame(
+    match_id = "m", event_id = 1:3, player_id = "p", player_name = "P",
+    x = 80, y = 50,
+    type_id = c(15L, 15L, 16L),        # saved, BLOCKED (saved bucket), goal
+    is_goal = c(0L, 0L, 1L),
+    season  = "2024-2025",
+    goalmouth_y = c(49, 50, 51), goalmouth_z = c(12, 19, 3),  # row 2 = placeholder z
+    is_blocked = c(FALSE, TRUE, FALSE),
+    body_part = "RightFoot", situation = "OpenPlay", big_chance = 0L,
+    stringsAsFactors = FALSE
+  )
+  feat <- suppressMessages(suppressWarnings(prepare_shots_for_xgot(shots)))
+  expect_equal(nrow(feat), 2)          # blocked shot excluded
+  expect_false(2L %in% feat$event_id)
+})
+
 test_that("aggregate_player_xmetrics emits a consistent finishing decomposition", {
   spadl <- data.frame(
     match_id = "m1", player_id = "A", player_name = "Pl A", team_id = "T",
@@ -148,7 +165,7 @@ test_that("add_xgot_to_spadl prefers the is_own_goal qualifier over position (#1
   )
   lookup <- data.frame(
     match_id = "m", event_id = 1:3, type_id = 16L,   # all goals
-    goalmouth_y = 50, goalmouth_z = 5,
+    goalmouth_y = 50, goalmouth_z = 5, is_blocked = FALSE,
     situation = "OpenPlay", stringsAsFactors = FALSE
   )
   # Qualifier branch must not fire the missing-column fallback warning.
@@ -156,6 +173,27 @@ test_that("add_xgot_to_spadl prefers the is_own_goal qualifier over position (#1
   expect_equal(r$xgot[1], 0.5)     # x<50 but NOT an own goal -> scored, not NA
   expect_equal(r$xgot[2], 0.5)
   expect_true(is.na(r$xgot[3]))    # own goal past halfway -> NA via qualifier
+})
+
+test_that("add_xgot_to_spadl excludes blocked shots (q82) from on-target (#176)", {
+  testthat::local_mocked_bindings(
+    predict_xgot = function(xgot_model, shot_features) rep(0.5, nrow(shot_features))
+  )
+  spadl <- data.frame(
+    match_id = "m", original_event_id = 1:2, action_type = "shot",
+    start_x = 85, start_y = 50, bodypart = "foot_right",
+    stringsAsFactors = FALSE
+  )
+  lookup <- data.frame(
+    match_id = "m", event_id = 1:2, type_id = 15L,      # both "Attempt Saved"
+    goalmouth_y = c(49, 50), goalmouth_z = c(12, 19),   # 2 = placeholder z
+    is_blocked = c(FALSE, TRUE),
+    situation = "OpenPlay", stringsAsFactors = FALSE
+  )
+  r <- suppressWarnings(suppressMessages(add_xgot_to_spadl(spadl, list(), lookup)))
+  expect_equal(r$xgot[1], 0.5)          # real save -> scored
+  expect_equal(r$xgot[2], 0)            # blocked -> off-target, cannot score
+  expect_equal(r$shot_on_target, c(TRUE, FALSE))
 })
 
 test_that("add_xgot_to_spadl falls back positionally for NA is_own_goal rows", {
@@ -171,7 +209,7 @@ test_that("add_xgot_to_spadl falls back positionally for NA is_own_goal rows", {
   )
   lookup <- data.frame(
     match_id = "m", event_id = 1:3, type_id = 16L,
-    goalmouth_y = 50, goalmouth_z = 5,
+    goalmouth_y = 50, goalmouth_z = 5, is_blocked = FALSE,
     situation = "OpenPlay", stringsAsFactors = FALSE
   )
   expect_warning(


### PR DESCRIPTION
## Summary
- panna#178: new opt-in `07b_snapshot_predictions.R` step archives dated `predictions.parquet` snapshots to a `predictions-history` release tag on pannadata (never clobbered, unlike `predictions-latest`), so a future as-at replay of a club league/cup can use genuine historical predictions. Mirrors the existing `12b_snapshot_wc_minutes.R` / `12c_snapshot_wc_strength.R` pattern. Wired into `predictions-pipeline.yml` as an always-on production step.
- Also includes the already-reviewed goalmouth_y (panna#175) and blocked-shots xGOT (panna#176) fixes sitting on `dev` ahead of the last `main` sync.

## Why now
`predictions-pipeline.yml` runs on the same `opta-scrape-complete` dispatch chain as the daily scraper — scheduled/dispatched workflows execute the default branch's copy, so this step does nothing until merged (same trap just hit twice on pannadata tonight, see pannadata#119).

## Test plan
- [x] `Rscript` syntax check on both changed R files
- [x] Step-key naming verified against `pipeline_utils.R::run_step()`'s lettered-step padding (`"7b"` → `step_07b_snapshot_predictions`, matches the `run_steps` list key)
- [ ] First real production run: confirm `predictions-history` release gets created and the dated parquet is sane

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Uq1VoAxMsYAtkYFhNXBmr