### PR TITLE
Retire the WC finals-week cron, and stop NEWS.md naming a version we passed 19 releases ago

### DIFF
--- a/.github/workflows/predictions-pipeline.yml
+++ b/.github/workflows/predictions-pipeline.yml
@@ -4,11 +4,12 @@ on:
   schedule:
     # Wednesday 8 AM UTC — after Tuesday matches + overnight Opta scrape
     - cron: '0 8 * * 3'
-    # WC 2026 finals week (Jul 12-19): daily 9 AM UTC backstop in case the
-    # 05:00 scrape's opta-scrape-complete dispatch fails. Cron has no year
-    # field so this re-fires on these July dates every year - harmless
-    # (concurrency-queued, idempotent); remove after the 2026 final.
-    - cron: '0 9 12-19 7 *'
+    # Removed 2026-08-13: the WC 2026 finals-week backstop ('0 9 12-19 7 *',
+    # daily 9 AM UTC over Jul 12-19) covered the case where the 05:00 scrape's
+    # opta-scrape-complete dispatch failed during the tournament. Its own
+    # comment said "remove after the 2026 final"; the final was Jul 19 2026.
+    # Cron has no year field, so left in place it would have re-fired on those
+    # eight July dates every year from now on.
   workflow_dispatch:
     inputs:
       force_rebuild:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: panna
 Title: Player Rating System for Football Using RAPM, SPM, and EPV Methods
-Version: 0.3.17
+Version: 0.3.20
 Authors@R:
     person("Pete", "Owen", , "pete.owen1@hotmail.co.uk", role = c("aut", "cre", "cph"))
 Description: Implements player ratings for football (soccer) from 'Opta'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# panna 0.3.1 (dev)
+# panna 0.3.20 (dev)
 
 ## Simplification campaign — dead code removal, vignette rewrite, API curation
 


### PR DESCRIPTION
Two small items, one of which only takes effect once it is on `main` — scheduled
workflows run the default branch's copy.

## 1. Retire the WC finals-week cron

`'0 9 12-19 7 *'` fired daily at 09:00 UTC over Jul 12-19 as a backstop for the
2026 World Cup, covering the case where the 05:00 scrape's
`opta-scrape-complete` dispatch failed. **Its own comment said "remove after the
2026 final".** The final was 2026-07-19.

Cron has no year field, so left in place it would have re-fired on those eight
July dates **every year from now on** — eight annual pipeline runs for a
tournament that has finished. It was listed for deletion on the Jul-20 gate day
in `pannaverse/docs/NEXT-STEPS.md` and outlived it by three weeks.

The Wednesday cron `'0 8 * * 3'` is untouched — and it is the one that matters,
since #184 hardened the cache download specifically to protect it.

The reason is kept as a comment where the line was rather than deleted silently:
the next person wondering whether a finals backstop ever existed should not have
to find it in `git log`.

## 2. `NEWS.md` development heading

It read `# panna 0.3.1 (dev)` while `DESCRIPTION` said 0.3.20. Everything from
0.3.1-dev onward has accumulated under that single heading, so it now names the
version it actually describes. Released headings (0.3.0 and earlier) are
untouched.

## Also carried in this PR

`1d3f3f1`, the bump to 0.3.20 — the version had sat at 0.3.17 across four merged
PRs (#181-#184, 12 commits since 2026-08-01), so "which release carries the WC
goal-difference fix" had no answer. The number is a batch bump, not one-per-PR,
and is not defended as exact.

## Verification

The workflow still parses, **exactly one cron remains** (`0 8 * * 3`), and all
three triggers survive:

```
schedule: [{'cron': '0 8 * * 3'}]
triggers: ['schedule', 'workflow_dispatch', 'repository_dispatch']
jobs: 1
```

No R code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACrDta9pqRFveLKGoSGBZm
