### PR TITLE
Fix the 13 test failures that were never flaky

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: panna
 Title: Player Rating System for Football Using RAPM, SPM, and EPV Methods
-Version: 0.3.22
+Version: 0.3.24
 Authors@R:
     person("Pete", "Owen", , "pete.owen1@hotmail.co.uk", role = c("aut", "cre", "cph"))
 Description: Implements player ratings for football (soccer) from 'Opta'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: panna
 Title: Player Rating System for Football Using RAPM, SPM, and EPV Methods
-Version: 0.3.24
+Version: 0.3.23
 Authors@R:
     person("Pete", "Owen", , "pete.owen1@hotmail.co.uk", role = c("aut", "cre", "cph"))
 Description: Implements player ratings for football (soccer) from 'Opta'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,43 @@
+# panna 0.3.23 (dev)
+
+## The 13 "flaky" test failures were one bug, hiding two more
+
+The suite had 13 failures across four files that each appeared to pass in
+isolation, so they read as flaky and had been left alone. They were neither
+flaky nor independent.
+
+* **A test was reloading the package mid-suite.** `test-publish-gating.R`
+  `source()`s real pipeline scripts, and every numbered step opens with
+  `devtools::load_all()` so it can run standalone. Under `devtools::test()` that
+  reloads the namespace mid-run, which (a) discards the
+  `local_mocked_bindings()` the sourcing test just installed — so `vb_publish`
+  un-mocks itself partway through and the test errors on its own — and (b)
+  swaps the package's session-state environments (`.opta_env`,
+  `.opta_remote_env`, `.vb_state`) for fresh ones, breaking every file that runs
+  after it. Confirmed by address: `.opta_remote_env` is a different environment
+  before and after. The package is already loaded when testthat runs, so the
+  script's own `load_all()` is redundant there; it is stubbed for the duration
+  of those four tests. **That alone fixed 11 of the 13.**
+* **`09_export_ratings.R` has published four files since panna#165** — the raw
+  RAPM pair must advance together with the shrunk pair — but the fixture still
+  supplied two, so the script aborted on `seasonal_rapm is empty or NULL`. The
+  M-RATINGS-PAIR invariant test had not been checking the current contract.
+* **The both-or-neither test asserted only an error _class_**, so it would have
+  passed against any early abort — vacuous the moment a fixture went stale,
+  which is exactly what had happened. It now asserts it reached `vb_publish`.
+* The fixture's synthetic `replacement` row exercised the export-boundary drop
+  without asserting it; row counts are now captured inside the mock (the script
+  unlinks its temp dir as soon as `vb_publish` returns) so the assertion fails
+  if the drop regresses.
+* Closed a second, non-failing leak: the two `download_opta_catalog` tests
+  cleared the session cache on the way in but not out, leaving a one-league
+  fixture catalog behind for later readers. A residual path still populates it
+  indirectly from elsewhere in that file; it causes no failures today.
+
+**723 tests, 0 failures.** Bisected in the real `devtools::test()` harness —
+sequential `test_file()` does not reproduce it, which is part of why it
+survived.
+
 # panna 0.3.22 (dev)
 
 ## Pipeline guards: partial loads and skipped steps now fail instead of reporting success

--- a/tests/testthat/test-opta-loaders.R
+++ b/tests/testthat/test-opta-loaders.R
@@ -308,11 +308,21 @@ test_that("download_opta_catalog treats stale local file as expired", {
     .package = "piggyback"
   )
 
-  # Clear any session cache so the test is deterministic.
+  # Clear any session cache so the test is deterministic -- and clear it AGAIN
+  # on exit. download_opta_catalog() caches whatever it returns, so without the
+  # defer this test leaves a one-league FIXTURE catalog in the session cache for
+  # every later test that reads it (list_opta_seasons(), resolve_league_season(),
+  # ...). Clearing only on the way in makes the test deterministic for itself
+  # while quietly poisoning everything downstream.
   .opta_remote_env <- asNamespace("panna")$.opta_remote_env
   if (exists("opta_catalog", envir = .opta_remote_env)) {
     rm("opta_catalog", envir = .opta_remote_env)
   }
+  withr::defer({
+    if (exists("opta_catalog", envir = .opta_remote_env)) {
+      rm("opta_catalog", envir = .opta_remote_env)
+    }
+  })
 
   # TTL 6h: 48h-old local is stale → should return fresh catalog.
   result <- download_opta_catalog(max_age_hours = 6)
@@ -344,11 +354,17 @@ test_that("download_opta_catalog accepts fresh local file within TTL", {
     .package = "panna"
   )
 
-  # Clear cache so it's forced to hit the local-file path.
+  # Clear cache so it's forced to hit the local-file path -- and on exit too,
+  # so the fixture catalog this loads doesn't outlive the test (see above).
   .opta_remote_env <- asNamespace("panna")$.opta_remote_env
   if (exists("opta_catalog", envir = .opta_remote_env)) {
     rm("opta_catalog", envir = .opta_remote_env)
   }
+  withr::defer({
+    if (exists("opta_catalog", envir = .opta_remote_env)) {
+      rm("opta_catalog", envir = .opta_remote_env)
+    }
+  })
 
   # Would fail if the "download" path ran (no pb_download stub here).
   result <- download_opta_catalog(max_age_hours = 6)

--- a/tests/testthat/test-publish-gating.R
+++ b/tests/testthat/test-publish-gating.R
@@ -11,8 +11,34 @@
 # batched into which tag's vb_publish() call, and that a failure propagates
 # to the pipeline runner instead of being swallowed -- without waiting out
 # vb_publish's real retry/backoff delays.
+#
+# Every pipeline script sourced below opens with `devtools::load_all()` (steps
+# 01-13 all carry that header, so a step can be run standalone). Under
+# devtools::test() that call RELOADS THE PACKAGE NAMESPACE MID-SUITE, which:
+#   1. discards the local_mocked_bindings() installed by the very test doing
+#      the sourcing -- so `vb_publish` un-mocks itself partway through and the
+#      test errors; and
+#   2. replaces the package's session-state environments (.opta_env,
+#      .opta_remote_env, .vb_state, .get_col_warned) with fresh ones, breaking
+#      every test file that runs AFTER this one in the same session.
+# Confirmed by address: the .opta_remote_env binding is a different environment
+# before and after sourcing a script with that header. This was the source of
+# 13 order-dependent failures across four test files -- each of which passes in
+# isolation, which is exactly why it went unnoticed.
+#
+# The package is already loaded by the time testthat runs, so the script's own
+# load_all() is redundant here -- the same situation as the pipeline
+# orchestrator, which the script header explicitly anticipates. Stub it out.
+local_no_reload <- function(env = parent.frame()) {
+  testthat::local_mocked_bindings(
+    load_all = function(...) invisible(NULL),
+    .package = "devtools",
+    .env = env
+  )
+}
 
 test_that("13_publish_release_data.R calls vb_publish once per non-empty tag with the registered files", {
+  local_no_reload()
   dir <- withr::local_tempdir()
   pred_file <- file.path(dir, "predictions.parquet")
   blog1 <- file.path(dir, "panna_ratings.parquet")
@@ -47,6 +73,7 @@ test_that("13_publish_release_data.R calls vb_publish once per non-empty tag wit
 })
 
 test_that("13_publish_release_data.R: a blog-latest failure propagates without being swallowed, after predictions-latest was attempted", {
+  local_no_reload()
   dir <- withr::local_tempdir()
   pred_file <- file.path(dir, "predictions.parquet")
   blog1 <- file.path(dir, "panna_ratings.parquet")
@@ -89,15 +116,43 @@ test_that("13_publish_release_data.R: a blog-latest failure propagates without b
   expect_true("blog-latest" %in% attempted_tags)
 })
 
-test_that("09_export_ratings.R publishes xRAPM+SPM in ONE vb_publish call (M-RATINGS-PAIR)", {
+# Fixtures for 09_export_ratings.R. It reads TWO caches and publishes FOUR
+# files: seasonal_xrapm + seasonal_spm (the original M-RATINGS-PAIR) and, since
+# panna#165, seasonal_rapm_raw + pooled_rapm_raw, which must advance together
+# with them. The fixture below was stale at two of those four -- it supplied
+# only xrapm/spm, so the script aborted on `seasonal_rapm is empty or NULL`.
+# That abort was invisible because these tests were ALSO failing on the
+# namespace reload described at the top of this file; fixing that surfaced it.
+.pg_rapm_frame <- function(n = 2L, season = FALSE) {
+  df <- data.frame(
+    player_id = c("p1", "replacement")[seq_len(n)],
+    player_name = c("Player One", "Replacement Level")[seq_len(n)],
+    rapm = seq_len(n) / 10,
+    offense = seq_len(n) / 20,
+    defense = -seq_len(n) / 20,
+    total_minutes = 900 * seq_len(n),
+    stringsAsFactors = FALSE
+  )
+  if (season) df$season_end_year <- 2025L
+  df
+}
+
+.pg_write_ratings_caches <- function(cache_dir) {
+  saveRDS(list(
+    seasonal_xrapm = data.frame(player_id = "p1", xrapm = 0.1),
+    seasonal_spm   = data.frame(player_id = "p1", spm = 0.2),
+    seasonal_rapm  = .pg_rapm_frame(season = TRUE)
+  ), file.path(cache_dir, "07_seasonal_ratings.rds"))
+  saveRDS(list(ratings = .pg_rapm_frame()),
+          file.path(cache_dir, "04_rapm.rds"))
+}
+
+test_that("09_export_ratings.R publishes the whole ratings set in ONE vb_publish call (M-RATINGS-PAIR)", {
+  local_no_reload()
   skip_if_not_installed("arrow")
   dir <- withr::local_tempdir()
   cache_dir <- dir
-  seasonal_results <- list(
-    seasonal_xrapm = data.frame(player_id = "p1", xrapm = 0.1),
-    seasonal_spm   = data.frame(player_id = "p1", spm = 0.2)
-  )
-  saveRDS(seasonal_results, file.path(cache_dir, "07_seasonal_ratings.rds"))
+  .pg_write_ratings_caches(cache_dir)
 
   local_mocked_bindings(
     pb_list = function(repo, tag) data.frame(file_name = character(0)),
@@ -118,27 +173,31 @@ test_that("09_export_ratings.R publishes xRAPM+SPM in ONE vb_publish call (M-RAT
   skip_if_not(file.exists(script), "09_export_ratings.R not found")
   source(script, local = TRUE)
 
-  expect_length(captured_paths, 2)
-  expect_true(any(grepl("seasonal_xrapm\\.parquet$", captured_paths)))
-  expect_true(any(grepl("seasonal_spm\\.parquet$", captured_paths)))
+  # All four in ONE call -- the point of the invariant is that the shrunk and
+  # raw ratings can never advance independently of each other.
+  expect_length(captured_paths, 4)
+  for (f in c("seasonal_xrapm", "seasonal_spm",
+              "seasonal_rapm_raw", "pooled_rapm_raw")) {
+    expect_true(any(grepl(paste0(f, "\\.parquet$"), captured_paths)),
+                info = paste(f, "missing from the published set"))
+  }
 })
 
 test_that("09_export_ratings.R: a vb_publish failure aborts the script (both-or-neither)", {
+  local_no_reload()
   skip_if_not_installed("arrow")
   dir <- withr::local_tempdir()
   cache_dir <- dir
-  seasonal_results <- list(
-    seasonal_xrapm = data.frame(player_id = "p1", xrapm = 0.1),
-    seasonal_spm   = data.frame(player_id = "p1", spm = 0.2)
-  )
-  saveRDS(seasonal_results, file.path(cache_dir, "07_seasonal_ratings.rds"))
+  .pg_write_ratings_caches(cache_dir)
 
   local_mocked_bindings(
     pb_list = function(repo, tag) data.frame(file_name = character(0)),
     .package = "piggyback"
   )
+  reached_publish <- FALSE
   local_mocked_bindings(
     vb_publish = function(paths, repo, tag, ...) {
+      reached_publish <<- TRUE
       cli::cli_abort("simulated seasonal_spm upload failure",
                       class = "vb_error_transient")
     },
@@ -150,4 +209,8 @@ test_that("09_export_ratings.R: a vb_publish failure aborts the script (both-or-
   skip_if_not(file.exists(script), "09_export_ratings.R not found")
 
   expect_error(source(script, local = TRUE), class = "vb_error_transient")
+  # The error must come FROM vb_publish, not from the script aborting earlier
+  # on a missing input. Without this the test passes vacuously the moment a
+  # fixture goes stale -- which is exactly what happened here.
+  expect_true(reached_publish)
 })

--- a/tests/testthat/test-publish-gating.R
+++ b/tests/testthat/test-publish-gating.R
@@ -160,9 +160,14 @@ test_that("09_export_ratings.R publishes the whole ratings set in ONE vb_publish
   )
 
   captured_paths <- NULL
+  captured_rows <- NULL
   local_mocked_bindings(
     vb_publish = function(paths, repo, tag, ...) {
       captured_paths <<- paths
+      # Read row counts HERE, inside the mock: the script unlinks its temp dir
+      # as soon as vb_publish returns, so by assertion time the files are gone.
+      captured_rows <<- vapply(paths, function(p) nrow(arrow::read_parquet(p)),
+                               integer(1))
       list(generation = "test-gen")
     },
     .package = "panna"
@@ -181,6 +186,14 @@ test_that("09_export_ratings.R publishes the whole ratings set in ONE vb_publish
     expect_true(any(grepl(paste0(f, "\\.parquet$"), captured_paths)),
                 info = paste(f, "missing from the published set"))
   }
+
+  # The fixture feeds 2 rows to each raw export, one of them the synthetic
+  # `replacement` player the script drops at the export boundary. Assert the
+  # drop actually happened -- without this the replacement row is inert
+  # scenery, present in the fixture but verifying nothing.
+  raw_idx <- grep("(seasonal_rapm_raw|pooled_rapm_raw)\\.parquet$", captured_paths)
+  expect_length(raw_idx, 2)
+  expect_equal(unname(captured_rows[raw_idx]), c(1L, 1L))
 })
 
 test_that("09_export_ratings.R: a vb_publish failure aborts the script (both-or-neither)", {

--- a/tests/testthat/test-publish-gating.R
+++ b/tests/testthat/test-publish-gating.R
@@ -30,6 +30,15 @@
 # load_all() is redundant here -- the same situation as the pipeline
 # orchestrator, which the script header explicitly anticipates. Stub it out.
 local_no_reload <- function(env = parent.frame()) {
+  # No-op when devtools is absent. It is not a dependency of this package, so
+  # it is NOT installed in the R CMD check environment, and mocking a binding
+  # in a package that cannot be loaded is a hard error rather than a skip.
+  # Nothing is lost by skipping the stub there: `data-raw/` is excluded from
+  # the built tarball, so the scripts these tests source do not exist under
+  # R CMD check and every one of them skips on the `file.exists(script)` guard
+  # below. The stub only ever matters for a local devtools::test() run, which
+  # is precisely where the mid-suite reload does its damage.
+  if (!requireNamespace("devtools", quietly = TRUE)) return(invisible(NULL))
   testthat::local_mocked_bindings(
     load_all = function(...) invisible(NULL),
     .package = "devtools",


### PR DESCRIPTION
The suite had 13 failures across four files that each appeared to pass in isolation, so they'd been living there as "known flaky". They were neither flaky nor independent — one root cause, plus two genuinely stale tests it was hiding.

## Root cause

`test-publish-gating.R` uses `source()` on real pipeline scripts, and every numbered step opens with `devtools::load_all()` so it can be run standalone. Under `devtools::test()` that **reloads the package namespace mid-run**, which:

1. **Discards the `local_mocked_bindings()` the sourcing test just installed** — `vb_publish` un-mocks itself partway through, so the test errors on its own.
2. **Swaps the package's session-state environments** (`.opta_env`, `.opta_remote_env`, `.vb_state`) for fresh ones, breaking every file that runs after it.

Confirmed by address: `.opta_remote_env` is a different environment before and after sourcing a script with that header.

The package is already loaded when testthat runs, so the script's own `load_all()` is redundant there — exactly the case its header comment anticipates for the orchestrator. Stubbed for the duration of those four tests. **That alone fixed 11 of the 13.**

## What it was hiding

The remaining 2 failed for a real reason:

- **`09_export_ratings.R` has published four files since panna#165** (the raw RAPM pair must advance together with the shrunk pair), and the fixture still supplied two — so the script aborted on `seasonal_rapm is empty or NULL`. The M-RATINGS-PAIR invariant test had not been checking the current contract. Fixture now supplies both caches; the assertion checks all four files.
- **The both-or-neither test asserted only an error _class_**, so it would have gone green against any early abort — vacuous the moment a fixture went stale, which is what happened. It now asserts it actually reached `vb_publish`.
- The fixture's `replacement` row exercised the export-boundary drop without asserting it. Row counts are now captured inside the mock (the script unlinks its temp dir as soon as `vb_publish` returns) and the assertion fails if the drop regresses.

Also closed a second, non-failing leak: the two `download_opta_catalog` tests cleared the session cache on the way in but not out, leaving a one-league fixture catalog behind for later readers. A residual path still populates it indirectly from elsewhere in that file; it causes no failures today and I left it.

## Result

**723 tests, 0 failures — first fully green run.** Verified the four previously-affected files pass both together and individually.

## Method note

Bisected in the real `devtools::test()` harness. Sequential `test_file()` does **not** reproduce this, which is part of why it survived — and why my first hypothesis (the catalog cache) was wrong: that leak is real, but clearing it changes nothing.

## Reviewed

A scoped `code-reviewer` agent verified the stub's scoping and unwinding, checked the new fixtures field-by-field against the live script, and confirmed the `reached_publish` assertion closes the vacuous-pass hole — running the modified tests rather than only reading them. No defects. Its one finding, the inert `replacement` row, is the last commit here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fdNfDw4oc1bNN1YrWmzrN