### PR TITLE
Fix the workflow comment quote that truncated the Rscript payload

### DIFF
--- a/.github/workflows/predictions-pipeline.yml
+++ b/.github/workflows/predictions-pipeline.yml
@@ -284,7 +284,7 @@ jobs:
               # These four stay TRUE across tournaments. run_predictions_opta.R
               # gates them at runtime on .wc2026_fixtures_remaining() and turns
               # them off by itself once the final is played, saying so in the
-              # log -- so a log line reading "DISABLING steps 11/12/12b/12c"
+              # log -- so a log line reading DISABLING steps 11/12/12b/12c
               # under a TRUE here is the gate working, not drift. They are also
               # non-fatal now: before 2026-08-21 a step-11 abort set
               # pipeline_failed and step 13 published nothing for eight days.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: panna
 Title: Player Rating System for Football Using RAPM, SPM, and EPV Methods
-Version: 0.3.23
+Version: 0.3.24
 Authors@R:
     person("Pete", "Owen", , "pete.owen1@hotmail.co.uk", role = c("aut", "cre", "cph"))
 Description: Implements player ratings for football (soccer) from 'Opta'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,22 @@
-# panna 0.3.23 (dev)
+# panna 0.3.24 (dev)
+
+## A double quote in a workflow comment truncated the R payload
+
+The first run on `main` after the fix below died two minutes in with
+`Error: unexpected end of input`. A comment added to
+`predictions-pipeline.yml` read `# so a log line reading "DISABLING steps
+11/12/12b/12c"`. Workflows run R via `Rscript -e "<payload>"`, and the shell
+ends that string at the first unescaped `"` — so the payload the shell handed
+R was **74 lines instead of 97**, cut off mid-comment. Harmless in a `.R`
+file; fatal here.
+
+YAML validation passed, every `.R` file parsed, and the review missed it,
+because nothing checked the string the *shell* would build.
+`tests/testthat/test-workflow-r-payloads.R` now reconstructs each
+`Rscript -e` payload the way the shell does and parses it. Mutation-tested:
+reintroducing the quote reproduces the production error verbatim.
+
+# panna 0.3.23
 
 ## The World Cup branch no longer takes the daily publish down with it
 

--- a/tests/testthat/test-workflow-r-payloads.R
+++ b/tests/testthat/test-workflow-r-payloads.R
@@ -1,0 +1,55 @@
+# Workflows run R through `Rscript -e "<payload>"`. The shell ends that string
+# at the FIRST unescaped double quote, so a single `"` anywhere in the payload
+# -- including inside an R comment, where it is harmless in a .R file --
+# silently truncates the script and R dies with "unexpected end of input".
+#
+# That is not hypothetical. On 2026-08-21 a comment reading
+#   # so a log line reading "DISABLING steps 11/12/12b/12c"
+# cut predictions-pipeline.yml's payload from 97 lines to 74 and failed the
+# run two minutes in. YAML validation passed, the R scripts themselves parsed,
+# and the review missed it: nothing checked the payload the SHELL would build.
+#
+# So check that: reconstruct each payload the way the shell would, and parse it.
+
+.workflow_r_payloads <- function(path) {
+  yml <- yaml::yaml.load_file(path)
+  out <- list()
+  for (job in yml$jobs) {
+    for (step in job$steps) {
+      run <- step$run
+      if (is.null(run) || !grepl('Rscript -e "', run, fixed = TRUE)) next
+      # Everything after the opening quote, truncated at the next one -- which
+      # is exactly what the shell passes to R.
+      after <- sub('^.*?Rscript -e "', "", run)
+      out[[length(out) + 1L]] <- list(
+        step = if (is.null(step$name)) "(unnamed)" else step$name,
+        payload = sub('".*$', "", after)
+      )
+    }
+  }
+  out
+}
+
+test_that("every Rscript -e payload in a workflow survives the shell and parses", {
+  wf_dir <- testthat::test_path("..", "..", ".github", "workflows")
+  skip_if_not(dir.exists(wf_dir), "workflows/ absent (installed package, not source tree)")
+  skip_if_not_installed("yaml")
+
+  files <- list.files(wf_dir, pattern = "[.]ya?ml$", full.names = TRUE)
+  expect_gt(length(files), 0)
+
+  for (f in files) {
+    for (p in .workflow_r_payloads(f)) {
+      err <- tryCatch({ parse(text = p$payload); NULL },
+                      error = function(e) conditionMessage(e))
+      expect_null(
+        err,
+        info = sprintf(
+          paste0("%s / step '%s': the payload the SHELL builds does not parse (%s).
+",
+                 "  A stray double quote -- in the R code OR in a comment -- ends the ",
+                 "`Rscript -e \"...\"` string early. Remove it; do not escape it."),
+          basename(f), p$step, if (is.null(err)) "" else trimws(err)))
+    }
+  }
+})


### PR DESCRIPTION
Hotfix for a bug I introduced in #194. The first Predictions Pipeline run on `main` after that merge died two minutes in:

```
##[error]Error: unexpected end of input
```

## Cause

A comment I added to `predictions-pipeline.yml` read:

```r
# so a log line reading "DISABLING steps 11/12/12b/12c"
```

Workflows run R through `Rscript -e "<payload>"`, and **the shell ends that string at the first unescaped `"`**. So the payload the shell handed R was **74 lines instead of 97**, cut off mid-comment. Measured both ways rather than assumed:

```
BEFORE: shell hands R 74 lines; last = '# them off by itself once the final is played, saying so in the'
AFTER:  shell hands R 97 lines; last = 'if (isTRUE(pipeline_failed)) quit(status = 1)'
```

Harmless in a `.R` file. Fatal here.

## Fix

The quote is gone. Nothing is escaped — an escaped quote would work but would leave the same trap for the next person.

## Why this got through, and what now catches it

YAML validation passed. Every `.R` file parsed. Two reviewers read the diff. **Nothing checked the string the *shell* builds**, which is a third artifact, distinct from both the YAML and the R files.

`tests/testthat/test-workflow-r-payloads.R` now reconstructs each `Rscript -e` payload the way the shell does — truncating at the first quote — and parses it, across every workflow in `.github/workflows`. Mutation-tested: reintroducing the quote fails with the production error verbatim, naming the file, the step, and the cause.

```
── Failure: every Rscript -e payload in a workflow survives the shell and parses ──
predictions-pipeline.yml / step 'Run predictions pipeline': the payload the SHELL
builds does not parse (<text>:75:0: unexpected end of input ...)
```

838 tests pass, 0 failures.

## Review disclosure

**Self-reviewed inline, no agents** — same precedent as #184 (recorded in `docs/DECISIONS.md`, 2026-08-13). The change is one comment line losing two characters, plus a new test, and it is verified by an actual parser in both directions rather than by reading. Disclosing rather than letting the gate look satisfied.

Also carries the hook's `DESCRIPTION` bump to 0.3.24 with the matching NEWS section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01533D7gX5RBR78vJbjFL4Yo