### PR TITLE
Unfreeze the World Cup blog export, and port the versebus silent-failure fixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: panna
 Title: Player Rating System for Football Using RAPM, SPM, and EPV Methods
-Version: 0.3.24
+Version: 0.3.25
 Authors@R:
     person("Pete", "Owen", , "pete.owen1@hotmail.co.uk", role = c("aut", "cre", "cph"))
 Description: Implements player ratings for football (soccer) from 'Opta'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,40 @@
 # panna 0.3.24 (dev)
 
+## versebus: four silent-failure defects ported from bouncer's review (panna#187)
+
+`R/versebus.R` was byte-identical to bouncer's pre-fix copy, so four defects
+found in a bouncer code review were live here at the same line numbers. All
+four turn a transient failure into a silently-accepted "everything is fine":
+
+* **`vb_read_manifest()`'s retry-once branch classified every error as
+  "confirmed absent"** instead of reusing `vb_classify_error()` like the
+  first attempt does. A network blip on the retry looked identical to the
+  manifest genuinely having been deleted, fell through to legacy mode, and
+  **disabled sha256 verification for every download on that tag for the rest
+  of the session** behind a one-time warning nobody would connect to the
+  cause.
+* **`vb_download()`'s `verify_by_size()` swallowed a failed asset listing**
+  and skipped the check entirely rather than distinguishing "listing worked,
+  asset not in it" (fine, nothing to check) from "the listing call itself
+  errored" (no check happened at all). This is the *only* integrity check on
+  an unmanifested tag -- the common case -- so a transient API failure meant
+  the file was moved into place and given a `.sha256` sidecar as though
+  verification had passed.
+* **`vb_publish()`'s cache-invalidation hook failed via bare
+  `try(..., silent = TRUE)`** -- the only failure path in this file with no
+  logging at all. A dead hook meant downstream consumers kept serving
+  pre-publish data indefinitely with nothing recording why.
+* **`vb_generation()` ran `max()` on `updated_at` with no `na.rm`.** One
+  unrelated asset missing a timestamp (which `vb_list_assets()` deliberately
+  tolerates as `NA` rather than failing the whole listing) silently turned
+  the entire generation into `NA`, indistinguishable from "no assets at
+  all". Latent today (no caller in this package yet).
+
+All four fixed in place per bouncer's `peteowen1/bouncer@86e2ebc`; each has a
+dedicated regression test in `tests/testthat/test-versebus.R`, mutation-tested
+by reverting the fix and confirming the test fails. `torpverse/torp/R/versebus.R`
+carries the same four defects (confirmed, not yet fixed) -- see panna#187.
+
 ## A double quote in a workflow comment truncated the R payload
 
 The first run on `main` after the fix below died two minutes in with

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# panna 0.3.24 (dev)
+# panna 0.3.25 (dev)
 
 ## versebus: four silent-failure defects ported from bouncer's review (panna#187)
 
@@ -34,6 +34,33 @@ All four fixed in place per bouncer's `peteowen1/bouncer@86e2ebc`; each has a
 dedicated regression test in `tests/testthat/test-versebus.R`, mutation-tested
 by reverting the fix and confirming the test fails. `torpverse/torp/R/versebus.R`
 carries the same four defects (confirmed, not yet fixed) -- see panna#187.
+## Step 12 now checks step 11 finished, not just that its files exist
+
+Review of the change below found the existence check was not enough, and the
+gap is not theoretical. Step 11 writes `wc2026_bt_ratings.parquet` **before**
+`simulate_world_cup()` runs and `wc2026_simulation.parquet` /
+`wc2026_group_expectations.parquet` **after**. So a failure inside the
+simulation — a documented, previously-observed one — leaves a *fresh* BT file
+beside *stale* simulation files, with all three present. `file.exists()` on
+the three passes, section 5 merges the two vintages into one
+`wc2026_team_strength.parquet`, and step 13 publishes it. Step 11 has been
+non-fatal since panna#194, so "failed partway and carried on" is now routine
+rather than rare.
+
+* **Step 11 writes a commit marker.** It deletes `.wc11_outputs_complete` on
+  entry and rewrites it only after all three outputs are on disk. Step 12
+  requires it, so a partial run reads as "not ready" rather than "ready".
+* **`build_id` is only stamped on files the run actually wrote.**
+  `.vb_generation_stamp()` is wall-clock plus run id — a per-run stamp, not a
+  data vintage — so stamping a file the run did not rewrite asserts a
+  freshness that isn't there, and hands two genuinely different vintages the
+  same id. That is precisely the signal the blog's `detectMixedBuild()` reads
+  to spot a torn publish. Skipped outputs now keep the `build_id` they were
+  last published with, which is the honest answer: they *are* from an earlier
+  run. Post-tournament this means the World Cup pages will show a "mixed data
+  build" label, correctly — the predictions refresh while the simulation stays
+  frozen at the final.
+
 ## Step 12's blog export ran into the WC2026 liveness gate it should never have been in
 
 panna#194's WC2026 liveness gate (0.3.23 below) disabled steps 11/12/12b/12c
@@ -73,6 +100,8 @@ header-only CSV) even after the separate #191 fix restored WC2026 rows to
   not, including the case where only one of the three step-11 files is
   present (must still count as unavailable). Mutation-tested: forcing
   `.wc11_available` to always `TRUE` reproduces the pre-fix hard error.
+
+# panna 0.3.24
 
 ## A double quote in a workflow comment truncated the R payload
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,45 @@
 # panna 0.3.24 (dev)
 
+## Step 12's blog export ran into the WC2026 liveness gate it should never have been in
+
+panna#194's WC2026 liveness gate (0.3.23 below) disabled steps 11/12/12b/12c
+together once the tournament was over. Step 12 should not have been on that
+list: it *exports*, it does not simulate. Its match-prediction exports
+(`wc2026_predictions.parquet`, `wc_history_predictions.parquet`) read only
+`07_predictions.rds` and are exactly as valid post-tournament as pre- — they
+are how the blog browses a *finished* World Cup — but with step 12 gated off,
+both files stayed frozen at their 2026-08-12 publish (0 rows / 140-byte
+header-only CSV) even after the separate #191 fix restored WC2026 rows to
+`07_predictions.rds`.
+
+* `run_predictions_opta.R` no longer includes `step_12_export_wc2026_blog` in
+  `.wc_steps` — step 12 now runs on every predictions-pipeline run,
+  regardless of tournament liveness. Steps 11, 12b and 12c stay gated (they
+  simulate, or snapshot a simulation in progress).
+* `12_export_wc2026_blog.R` computes `.wc11_available` from whether step 11's
+  three output files exist (`wc2026_simulation.parquet`,
+  `wc2026_group_expectations.parquet`, `wc2026_bt_ratings.parquet`) and gates
+  the sections that read them (3, 4, 5, 5c, and the reference-fact validation
+  in 8) on that flag instead of hard-erroring via a bare `read_parquet()`.
+  Sections 2/2b (match predictions) and the existing build_id-stamp/publish-
+  registration logic in 6/7 are unaffected — 6/7 already tolerated absent
+  files file-by-file. The four step-11-dependent sections are gated together
+  as one block, not independently, because section 5's team-strength numbers
+  and section 5c's per-player squad ratings are two views of one
+  "team == Sigma(squad)" invariant the blog relies on; refreshing one without
+  the other would break it.
+* Also fixed while adding a Windows-run test for this: the build_id-stamp
+  loop in section 6 read and immediately overwrote the same parquet path
+  without `mmap = FALSE`, which fails with a file-locking error on Windows
+  (section 3 already used `mmap = FALSE` for exactly this read-then-rewrite
+  pattern).
+* `tests/testthat/test-wc2026-export.R` sources the real step-12 script
+  against a fixture cache holding only `07_predictions.rds` and proves the
+  match-prediction exports are written and the step-11-dependent ones are
+  not, including the case where only one of the three step-11 files is
+  present (must still count as unavailable). Mutation-tested: forcing
+  `.wc11_available` to always `TRUE` reproduces the pre-fix hard error.
+
 ## A double quote in a workflow comment truncated the R payload
 
 The first run on `main` after the fix below died two minutes in with

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,13 +13,15 @@ four turn a transient failure into a silently-accepted "everything is fine":
   **disabled sha256 verification for every download on that tag for the rest
   of the session** behind a one-time warning nobody would connect to the
   cause.
-* **`vb_download()`'s `verify_by_size()` swallowed a failed asset listing**
-  and skipped the check entirely rather than distinguishing "listing worked,
-  asset not in it" (fine, nothing to check) from "the listing call itself
-  errored" (no check happened at all). This is the *only* integrity check on
-  an unmanifested tag -- the common case -- so a transient API failure meant
-  the file was moved into place and given a `.sha256` sidecar as though
-  verification had passed.
+* **`vb_download()`'s `verify_by_size()` swallowed a failed asset listing
+  silently.** It now warns, naming the file and saying it was accepted
+  *without* verification. It deliberately still accepts it: this function is
+  the sha-mismatch path's graceful degradation, and a stale manifest entry is
+  far more common than real corruption, so aborting on a transient API blip
+  would brick the asset until someone republished the manifest -- the exact
+  outcome that caller exists to prevent. bouncer shipped the aborting version,
+  its CI caught it, and it was reverted (`bouncerverse/bouncer@5edd3ac`,
+  2026-08-16) for this reason. Only the silence was a defect.
 * **`vb_publish()`'s cache-invalidation hook failed via bare
   `try(..., silent = TRUE)`** -- the only failure path in this file with no
   logging at all. A dead hook meant downstream consumers kept serving

--- a/R/versebus.R
+++ b/R/versebus.R
@@ -422,14 +422,22 @@ vb_download <- function(repo, tag, name, dest,
               "vb_error_integrity")
   }
   verify_by_size <- function() {
-    # Distinguish "listing worked, asset is not in it" (legitimately nothing
-    # to check) from "the listing call failed" (no check happened at all).
-    # Swallowing the latter meant an unmanifested asset -- the common case --
-    # was moved into place and given a .sha256 sidecar with zero integrity
-    # checking, invisibly, on any transient API failure.
+    # The defect here was SILENCE, not the fallback. Trusting the download
+    # when the listing is unavailable is deliberate: this function is also
+    # the sha-mismatch path's graceful degradation (see the caller below),
+    # and a stale manifest entry is far more common than real corruption, so
+    # aborting on a transient API blip would brick the asset until someone
+    # manually republished the manifest -- the exact outcome that caller
+    # exists to avoid. bouncer shipped the abort version, CI caught it, and
+    # it was reverted in bouncerverse/bouncer 5edd3ac (2026-08-16) for this
+    # reason. Keep the behaviour; remove the silence.
     listed <- tryCatch(vb_list_assets(repo, tag), error = function(e) {
-      .vb_abort("{.val {name}}: could not list assets to size-check the download",
-                "vb_error_transient")
+      cli::cli_warn(c(
+        "{.val {name}}: could not list assets to size-check the download
+         ({conditionMessage(e)})",
+        "!" = "Accepted WITHOUT verification -- no manifest entry and no live
+               listing to corroborate it."))
+      NULL
     })
     if (!is.null(listed) && name %in% listed$name) {
       want <- listed$size[listed$name == name][1L]

--- a/R/versebus.R
+++ b/R/versebus.R
@@ -254,7 +254,16 @@ vb_read_manifest <- function(repo, tag, required = FALSE) {
   })
   if (is.null(m) && isTRUE(.vb_state[[paste0("seen_", key)]])) {
     Sys.sleep(10)
-    m <- tryCatch(fetch(), error = function(e) NULL)
+    # Classify the retry exactly as the first attempt does. Swallowing every
+    # error here turned a network blip into "the manifest is gone", which
+    # falls through to legacy mode and runs the rest of the session with
+    # sha256 verification silently disabled -- the precise inversion of this
+    # file's own rule that an uncertain classification is transient, never
+    # absent.
+    m <- tryCatch(fetch(), error = function(e) {
+      if (vb_classify_error(e) == "absent") return(NULL)
+      stop(e)
+    })
   }
   if (is.null(m)) {
     # A tag with no manifest at all is a bootstrap/legacy state, not an
@@ -413,7 +422,15 @@ vb_download <- function(repo, tag, name, dest,
               "vb_error_integrity")
   }
   verify_by_size <- function() {
-    listed <- tryCatch(vb_list_assets(repo, tag), error = function(e) NULL)
+    # Distinguish "listing worked, asset is not in it" (legitimately nothing
+    # to check) from "the listing call failed" (no check happened at all).
+    # Swallowing the latter meant an unmanifested asset -- the common case --
+    # was moved into place and given a .sha256 sidecar with zero integrity
+    # checking, invisibly, on any transient API failure.
+    listed <- tryCatch(vb_list_assets(repo, tag), error = function(e) {
+      .vb_abort("{.val {name}}: could not list assets to size-check the download",
+                "vb_error_transient")
+    })
     if (!is.null(listed) && name %in% listed$name) {
       want <- listed$size[listed$name == name][1L]
       if (!isTRUE(all.equal(as.numeric(file.size(tmp)), want))) {
@@ -484,8 +501,13 @@ vb_generation <- function(repo, tag) {
   if (!is.null(m) && !is.null(m$generation)) return(m$generation)
   assets <- vb_list_assets(repo, tag)
   if (nrow(assets) == 0L) return(NA_character_)
-  # per C:\dev\CLAUDE.md: asset updatedAt, never release createdAt
-  max(assets$updated_at)
+  # per C:\dev\CLAUDE.md: asset updatedAt, never release createdAt.
+  # na.rm because vb_list_assets deliberately fills NA for an asset missing
+  # updated_at -- without it, one malformed UNRELATED asset silently makes
+  # the whole generation NA, indistinguishable from the no-assets case.
+  stamps <- assets$updated_at[!is.na(assets$updated_at)]
+  if (!length(stamps)) return(NA_character_)
+  max(stamps)
 }
 
 #' Manifest-last atomic publish (the versebus producer pattern)
@@ -655,7 +677,16 @@ vb_publish <- function(paths, repo, tag,
 
   # 7. Own-write cache invalidation hook.
   hook <- getOption("versebus.on_publish")
-  if (is.function(hook)) try(hook(repo, tag), silent = TRUE)
+  if (is.function(hook)) {
+    # The publish itself has already succeeded, so a hook failure must not
+    # abort -- but it must not be invisible either. The hook exists so
+    # consumers refresh after a publish; if it dies silently they serve
+    # pre-publish data indefinitely with nothing recording why.
+    tryCatch(hook(repo, tag), error = function(e) {
+      cli::cli_warn(c("vb_publish: cache-invalidation hook failed: {conditionMessage(e)}",
+                      "i" = "The publish succeeded; downstream readers may serve stale data until refreshed."))
+    })
+  }
 
   cli::cli_alert_success("vb_publish: {length(entries)} asset(s) committed to {repo}@{tag} (generation {manifest$generation})")
   invisible(manifest)

--- a/data-raw/match-predictions-opta/11_simulate_wc2026.R
+++ b/data-raw/match-predictions-opta/11_simulate_wc2026.R
@@ -113,6 +113,22 @@ if (nrow(wc) == 0L || isTRUE(n_remaining == 0L)) {
 # Every knockout tie is predicted with the same 170-feature goals + outcome
 # models as the group stage (no Bradley-Terry compression).
 
+# Commit marker for step 12 (panna#180 review). Step 11 writes its three
+# outputs at different points -- wc2026_bt_ratings.parquet BEFORE
+# simulate_world_cup() runs, wc2026_simulation.parquet and
+# wc2026_group_expectations.parquet after -- so a failure inside the
+# simulation leaves a FRESH bt file beside STALE sim files, all three
+# present. Step 12 used to gate on file.exists() across the three, which
+# passes in exactly that state and merges two vintages into one published
+# wc2026_team_strength.parquet.
+#
+# Step 11 is non-fatal since panna#194, so "failed partway" no longer stops
+# the pipeline -- it is a routine event. Hence a marker, deleted here and
+# rewritten only after all three files are on disk: its presence means one
+# run produced the complete set.
+.wc11_marker <- file.path(cache_dir, ".wc11_outputs_complete")
+unlink(.wc11_marker)
+
 knockout <- build_knockout_lookup(
   match_dataset  = match_dataset,
   goals_models   = goals_models,
@@ -177,6 +193,10 @@ arrow::write_parquet(sim$summary,
                        file.path(cache_dir, "wc2026_simulation.parquet"))
 arrow::write_parquet(sim$group_table,
                        file.path(cache_dir, "wc2026_group_expectations.parquet"))
+
+# All three outputs are now on disk from THIS run -- see the marker comment
+# above build_knockout_lookup(). Written last, deliberately.
+writeLines(format(Sys.time(), "%Y-%m-%dT%H:%M:%OS3Z", tz = "UTC"), .wc11_marker)
 
 cat("\n=== Top 16 by Champion probability ===\n")
 print(head(as.data.table(sim$summary), 16))

--- a/data-raw/match-predictions-opta/12_export_wc2026_blog.R
+++ b/data-raw/match-predictions-opta/12_export_wc2026_blog.R
@@ -131,283 +131,318 @@ if (.n26 != nrow(wc_pred)) {
                   .n26, wc_season, nrow(wc_pred)), call. = FALSE, immediate. = TRUE)
 }
 
-# 3. Simulation — per-team round/champion probabilities ----
-
-sim <- as.data.table(read_parquet(file.path(cache_dir, "wc2026_simulation.parquet"), mmap = FALSE))
-# p_R32 (top-2 + best-thirds reach, tracked by simulate_world_cup since
-# 2026-06-12) is intersect-guarded so a stale upstream parquet still exports.
-sim_cols <- intersect(c("team", "group", "p_R32", "p_R16", "p_QF", "p_SF", "p_final", "p_champ"), names(sim))
-sim <- sim[, ..sim_cols]
-setorder(sim, -p_champ)
-write_parquet(sim, file.path(cache_dir, "wc2026_simulation.parquet"))
-message(sprintf("  wc2026_simulation.parquet: %d teams", nrow(sim)))
-
-# 4. Group-stage finish probabilities ----
-
-grp <- as.data.table(read_parquet(file.path(cache_dir,
-                                            "wc2026_group_expectations.parquet")))
-grp[, advance := round(pos1 + pos2, 1)]   # win or runner-up
-grp <- grp[, .(group, team,
-               win_group = pos1, runner_up = pos2, third = pos3, fourth = pos4,
-               advance)]
-setorder(grp, group, -win_group)
-write_parquet(grp, file.path(cache_dir, "wc2026_groups.parquet"))
-message(sprintf("  wc2026_groups.parquet: %d team-rows", nrow(grp)))
-
-# 5. Squad player ratings + team strength ----
-# Team strength is the MINUTES-WEIGHTED SUM of the player ratings shown in
-# wc2026_squads.parquet: team_metric = Σ_squad (expected_minutes_norm / 90) *
-# player_metric. So a team's rating literally equals the weighted sum of its
-# displayed players and reconciles by construction.
+# 3-5c. Step 11's outputs: simulation, group expectations, BT ratings, and
+# the squad/team-strength exports built from them ----
+# Sections 3, 4, 5 and 5c all read files step 11 writes (wc2026_simulation.
+# parquet, wc2026_group_expectations.parquet, wc2026_bt_ratings.parquet) via
+# bare read_parquet() calls that hard-error if the file is absent. They are
+# gated together behind ONE flag rather than four separate guards because
+# they are not independent: section 5's team-strength numbers and section
+# 5c's per-player squad ratings are two views of the same "team ==
+# Sigma(squad)" invariant (see the comment above section 5) -- refreshing
+# squad ratings without refreshing team strength in the same run would break
+# that reconciliation. So either all four sections run against a consistent
+# step-11 snapshot, or none of them do.
 #
-# We deliberately do NOT reuse the match-dataset home_sum_* features here. Those
-# carry the PREDICTION-MODEL versions of the ratings — date-specific live SPM for
-# panna, and WC-population-centered live PSR (step 02's date-specific path centers
-# over only the upcoming WC players, not the league). Those are correct for the
-# XGBoost match model (which uses home-away diffs, so the centering constant
-# cancels) but are a DIFFERENT estimator than the career-trait panna / league-
-# centered seasonal PSR the blog displays per player — which made the old team PSR collapse
-# to ~0 for all but the deepest squads. elo stays a match-dataset team property
-# (not squad-derived). BT strength + champ prob come from the sim. See METRICS.md
-# §14 and the step-02 WC-centering note.
+# The WC2026 liveness gate in run_predictions_opta.R turns step 11 off once
+# the tournament ends; wc2026_simulation.parquet et al. then simply stop
+# being refreshed and this step keeps re-stamping + re-publishing whatever
+# step 11 last wrote -- harmless. This flag exists for the other case: a
+# cache that never ran step 11 at all (a fresh clone, or a standalone step-12
+# run before 2026-06-11), where these files are absent outright.
+.wc11_sim_path <- file.path(cache_dir, "wc2026_simulation.parquet")
+.wc11_grp_path <- file.path(cache_dir, "wc2026_group_expectations.parquet")
+.wc11_bt_path  <- file.path(cache_dir, "wc2026_bt_ratings.parquet")
+.wc11_available <- all(file.exists(c(.wc11_sim_path, .wc11_grp_path, .wc11_bt_path)))
 
-md <- as.data.frame(readRDS(file.path(cache_dir, "04_match_dataset.rds")))
-wc <- md[md$league == WC2026_LEAGUE & md$season == wc_season &
-           !is.na(md$home_team) & md$home_team != "" &
-           !is.na(md$away_team) & md$away_team != "", ]
-teams <- sort(unique(c(wc$home_team, wc$away_team)))
+if (.wc11_available) {
+  # 3. Simulation — per-team round/champion probabilities ----
 
-# elo is a team property in the match dataset: pull home_elo (fall back away_elo).
-# Returns NA (not numeric(0)) on missing data so the guard below can surface it.
-team_metric <- function(tm, base) {
-  pick <- function(rows, col) {
-    if (!col %in% names(rows) || nrow(rows) == 0L) return(NA_real_)
-    v <- rows[[col]][1]
-    if (length(v) == 0L) NA_real_ else as.numeric(v)
+  sim <- as.data.table(read_parquet(file.path(cache_dir, "wc2026_simulation.parquet"), mmap = FALSE))
+  # p_R32 (top-2 + best-thirds reach, tracked by simulate_world_cup since
+  # 2026-06-12) is intersect-guarded so a stale upstream parquet still exports.
+  sim_cols <- intersect(c("team", "group", "p_R32", "p_R16", "p_QF", "p_SF", "p_final", "p_champ"), names(sim))
+  sim <- sim[, ..sim_cols]
+  setorder(sim, -p_champ)
+  write_parquet(sim, file.path(cache_dir, "wc2026_simulation.parquet"))
+  message(sprintf("  wc2026_simulation.parquet: %d teams", nrow(sim)))
+
+  # 4. Group-stage finish probabilities ----
+
+  grp <- as.data.table(read_parquet(file.path(cache_dir,
+                                              "wc2026_group_expectations.parquet")))
+  grp[, advance := round(pos1 + pos2, 1)]   # win or runner-up
+  grp <- grp[, .(group, team,
+                 win_group = pos1, runner_up = pos2, third = pos3, fourth = pos4,
+                 advance)]
+  setorder(grp, group, -win_group)
+  write_parquet(grp, file.path(cache_dir, "wc2026_groups.parquet"))
+  message(sprintf("  wc2026_groups.parquet: %d team-rows", nrow(grp)))
+
+  # 5. Squad player ratings + team strength ----
+  # Team strength is the MINUTES-WEIGHTED SUM of the player ratings shown in
+  # wc2026_squads.parquet: team_metric = Σ_squad (expected_minutes_norm / 90) *
+  # player_metric. So a team's rating literally equals the weighted sum of its
+  # displayed players and reconciles by construction.
+  #
+  # We deliberately do NOT reuse the match-dataset home_sum_* features here. Those
+  # carry the PREDICTION-MODEL versions of the ratings — date-specific live SPM for
+  # panna, and WC-population-centered live PSR (step 02's date-specific path centers
+  # over only the upcoming WC players, not the league). Those are correct for the
+  # XGBoost match model (which uses home-away diffs, so the centering constant
+  # cancels) but are a DIFFERENT estimator than the career-trait panna / league-
+  # centered seasonal PSR the blog displays per player — which made the old team PSR collapse
+  # to ~0 for all but the deepest squads. elo stays a match-dataset team property
+  # (not squad-derived). BT strength + champ prob come from the sim. See METRICS.md
+  # §14 and the step-02 WC-centering note.
+
+  md <- as.data.frame(readRDS(file.path(cache_dir, "04_match_dataset.rds")))
+  wc <- md[md$league == WC2026_LEAGUE & md$season == wc_season &
+             !is.na(md$home_team) & md$home_team != "" &
+             !is.na(md$away_team) & md$away_team != "", ]
+  teams <- sort(unique(c(wc$home_team, wc$away_team)))
+
+  # elo is a team property in the match dataset: pull home_elo (fall back away_elo).
+  # Returns NA (not numeric(0)) on missing data so the guard below can surface it.
+  team_metric <- function(tm, base) {
+    pick <- function(rows, col) {
+      if (!col %in% names(rows) || nrow(rows) == 0L) return(NA_real_)
+      v <- rows[[col]][1]
+      if (length(v) == 0L) NA_real_ else as.numeric(v)
+    }
+    hr <- wc[!is.na(wc$home_team) & wc$home_team == tm, ]
+    if (nrow(hr) > 0) {
+      val <- pick(hr, paste0("home_", base))
+      if (!is.na(val)) return(val)
+    }
+    ar <- wc[!is.na(wc$away_team) & wc$away_team == tm, ]
+    pick(ar, paste0("away_", base))
   }
-  hr <- wc[!is.na(wc$home_team) & wc$home_team == tm, ]
-  if (nrow(hr) > 0) {
-    val <- pick(hr, paste0("home_", base))
-    if (!is.na(val)) return(val)
+
+  # --- Squad player ratings: career-trait panna + league-centered seasonal PSR +
+  # latest weekly EPR — all point-in-time player RATINGS (not season aggregates).
+  # SAME source the per-player squad table publishes below (section 5c reuses
+  # squad_out), so team == Σ(players shown). ---
+  squads_path <- file.path(cache_dir, "wc2026_announced_squads.parquet")
+  if (!file.exists(squads_path)) {
+    stop("wc2026_announced_squads.parquet not found in ", cache_dir,
+         " — run announced_squads.R (step 02) first.")
   }
-  ar <- wc[!is.na(wc$away_team) & wc$away_team == tm, ]
-  pick(ar, paste0("away_", base))
-}
+  squads <- as.data.table(read_parquet(squads_path))
+  # Dedup: one row per (team, player), keep the highest expected-minutes source row.
+  setorder(squads, team_name, player_id, -expected_minutes_norm)
+  squads <- unique(squads, by = c("team_name", "player_id"))
 
-# --- Squad player ratings: career-trait panna + league-centered seasonal PSR +
-# latest weekly EPR — all point-in-time player RATINGS (not season aggregates).
-# SAME source the per-player squad table publishes below (section 5c reuses
-# squad_out), so team == Σ(players shown). ---
-squads_path <- file.path(cache_dir, "wc2026_announced_squads.parquet")
-if (!file.exists(squads_path)) {
-  stop("wc2026_announced_squads.parquet not found in ", cache_dir,
-       " — run announced_squads.R (step 02) first.")
-}
-squads <- as.data.table(read_parquet(squads_path))
-# Dedup: one row per (team, player), keep the highest expected-minutes source row.
-setorder(squads, team_name, player_id, -expected_minutes_norm)
-squads <- unique(squads, by = c("team_name", "player_id"))
+  sq_skill_path <- file.path("data-raw", "cache-skills", "06_seasonal_ratings.rds")
+  sq_raw_path   <- file.path("data-raw", "cache-opta", "07_seasonal_ratings.rds")
+  sq_seasonal <- if (file.exists(sq_skill_path)) readRDS(sq_skill_path) else readRDS(sq_raw_path)
 
-sq_skill_path <- file.path("data-raw", "cache-skills", "06_seasonal_ratings.rds")
-sq_raw_path   <- file.path("data-raw", "cache-opta", "07_seasonal_ratings.rds")
-sq_seasonal <- if (file.exists(sq_skill_path)) readRDS(sq_skill_path) else readRDS(sq_raw_path)
+  # panna = the career-trait RATING (decay-weighted multi-season xRAPM, point-in-time
+  # "best guess of next game") — the SAME `panna` the main blog ratings publish since
+  # 2026-06-09. NOT the single-season xRAPM (that's a season aggregate, a different
+  # quantity that used to be mislabeled `panna`). Source: career_panna.parquet
+  # (estimated-skills/09_career_panna.R via fit_career_rapm), on pannadata's
+  # ratings-data release. offense/defense = the career-trait decomposition
+  # (panna_offense/panna_defense; internal negative=good, flipped at display below).
+  cp_path <- file.path(opta_data_dir(), "career_panna.parquet")
+  if (!file.exists(cp_path)) {
+    stop("career_panna.parquet not found at ", cp_path, " — the WC squad panna IS the ",
+         "career trait, not season xRAPM. Add it to the predictions-pipeline download ",
+         "list (pannadata ratings-data release) or run estimated-skills/09_career_panna.R.",
+         call. = FALSE)
+  }
+  sq_panna <- as.data.table(read_parquet(cp_path))[
+    , .(player_id, panna, offense = panna_offense, defense = panna_defense, total_minutes)]
 
-# panna = the career-trait RATING (decay-weighted multi-season xRAPM, point-in-time
-# "best guess of next game") — the SAME `panna` the main blog ratings publish since
-# 2026-06-09. NOT the single-season xRAPM (that's a season aggregate, a different
-# quantity that used to be mislabeled `panna`). Source: career_panna.parquet
-# (estimated-skills/09_career_panna.R via fit_career_rapm), on pannadata's
-# ratings-data release. offense/defense = the career-trait decomposition
-# (panna_offense/panna_defense; internal negative=good, flipped at display below).
-cp_path <- file.path(opta_data_dir(), "career_panna.parquet")
-if (!file.exists(cp_path)) {
-  stop("career_panna.parquet not found at ", cp_path, " — the WC squad panna IS the ",
-       "career trait, not season xRAPM. Add it to the predictions-pipeline download ",
-       "list (pannadata ratings-data release) or run estimated-skills/09_career_panna.R.",
-       call. = FALSE)
-}
-sq_panna <- as.data.table(read_parquet(cp_path))[
-  , .(player_id, panna, offense = panna_offense, defense = panna_defense, total_minutes)]
-
-sq_psr <- if (!is.null(sq_seasonal$seasonal_psr) && nrow(sq_seasonal$seasonal_psr) > 0) {
-  p <- as.data.table(sq_seasonal$seasonal_psr)
-  p[order(player_id, -season_end_year), .SD[1L], by = player_id, .SDcols = "psr"]
-} else NULL
-
-sq_epr <- {
-  ep <- file.path(opta_data_dir(), "opta_epr_weekly.parquet")
-  if (file.exists(ep)) {
-    e <- as.data.table(read_parquet(ep))
-    e[, snapshot_date := as.Date(snapshot_date)]
-    e[order(player_id, -snapshot_date), .SD[1L], by = player_id, .SDcols = "epr"]
+  sq_psr <- if (!is.null(sq_seasonal$seasonal_psr) && nrow(sq_seasonal$seasonal_psr) > 0) {
+    p <- as.data.table(sq_seasonal$seasonal_psr)
+    p[order(player_id, -season_end_year), .SD[1L], by = player_id, .SDcols = "psr"]
   } else NULL
-}
 
-squad_out <- squads[, .(team = team_name, player_id, player_name, position,
-                        expected_minutes_norm, is_starter_pred)]
-squad_out[, group := unname(team_group[team])]
-squad_out <- merge(squad_out, sq_panna, by = "player_id", all.x = TRUE)
-if (!is.null(sq_psr)) squad_out <- merge(squad_out, sq_psr, by = "player_id", all.x = TRUE)
-if (!is.null(sq_epr)) squad_out <- merge(squad_out, sq_epr, by = "player_id", all.x = TRUE)
-for (col in c("panna", "offense", "defense", "epr", "psr", "total_minutes"))
-  if (!col %in% names(squad_out)) squad_out[[col]] <- NA_real_
-
-# --- Team strength = Σ_squad (expected_minutes_norm / 90) * player_metric.
-# NA (unrated player) contributes 0 to the sum but stays in the squad headcount. ---
-.wsum <- function(x, w) sum(w * data.table::fifelse(is.na(x), 0, x))
-agg <- squad_out[, {
-  w <- expected_minutes_norm / 90
-  list(panna   = .wsum(panna,   w),
-       offense = .wsum(offense, w),
-       defense = .wsum(defense, w),
-       epr     = .wsum(epr,     w),
-       psr     = .wsum(psr,     w),
-       squad_n = .N,
-       n_rated = sum(!is.na(panna)))
-}, by = team]
-
-strength <- data.table(team = teams, group = unname(team_group[teams]))
-strength <- merge(strength, agg[, .(team, panna, offense, defense, epr, psr)],
-                  by = "team", all.x = TRUE)
-strength[, elo := vapply(teams, team_metric, numeric(1), base = "elo")]
-for (m in c("panna", "offense", "defense", "epr", "psr", "elo"))
-  strength[[m]] <- round(strength[[m]], 4)
-
-# HARD STOP guards. Per [[feedback-no-silent-imputation]] a published rating must
-# HALT on a structural failure, not ship partial/zeroed data. Two failure modes:
-#   1. elo missing for a team — match-dataset property absent (name drift / no row).
-#   2. a team has NO squad aggregate — its name didn't match the announced-squad
-#      team_name, or it has no announced squad (would leave panna NA after the join).
-# Plus a wholesale-zero tripwire: now that the aggregate sums NA->0, a squad
-# rating-join failure surfaces as a metric that is 0 for (nearly) every team
-# rather than the old all-NA symptom — catch that too.
-elo_na <- strength$team[is.na(strength$elo)]
-if (length(elo_na) > 0L) {
-  stop(sprintf("wc2026_team_strength: elo missing for %d team(s): %s — match-dataset name drift or missing WC row.",
-               length(elo_na), paste(elo_na, collapse = ", ")), call. = FALSE)
-}
-squad_missing <- strength$team[is.na(strength$panna)]
-if (length(squad_missing) > 0L) {
-  stop(sprintf("wc2026_team_strength: no squad aggregate for %d team(s): %s — announced-squad team_name mismatch vs the match dataset, or a missing announced squad. Fix the name mapping (or announced_squads.R) before publishing.",
-               length(squad_missing), paste(squad_missing, collapse = ", ")), call. = FALSE)
-}
-for (mt in c("panna", "epr", "psr")) {
-  nz <- mean(strength[[mt]] != 0, na.rm = TRUE)
-  if (nz < 0.5) {
-    stop(sprintf("wc2026_team_strength: %s is zero for %.0f%% of teams — likely a squad rating-join failure (check seasonal_%s in cache-skills/06 or cache-opta/07, and the player_id join). Refusing to publish.",
-                 mt, 100 * (1 - nz), mt), call. = FALSE)
+  sq_epr <- {
+    ep <- file.path(opta_data_dir(), "opta_epr_weekly.parquet")
+    if (file.exists(ep)) {
+      e <- as.data.table(read_parquet(ep))
+      e[, snapshot_date := as.Date(snapshot_date)]
+      e[order(player_id, -snapshot_date), .SD[1L], by = player_id, .SDcols = "epr"]
+    } else NULL
   }
-}
 
-# Published convention: defence as positive = good (internal model has
-# negative = good, since defense is "xG added to the opponent").
-strength[, defense := -defense]
+  squad_out <- squads[, .(team = team_name, player_id, player_name, position,
+                          expected_minutes_norm, is_starter_pred)]
+  squad_out[, group := unname(team_group[team])]
+  squad_out <- merge(squad_out, sq_panna, by = "player_id", all.x = TRUE)
+  if (!is.null(sq_psr)) squad_out <- merge(squad_out, sq_psr, by = "player_id", all.x = TRUE)
+  if (!is.null(sq_epr)) squad_out <- merge(squad_out, sq_epr, by = "player_id", all.x = TRUE)
+  for (col in c("panna", "offense", "defense", "epr", "psr", "total_minutes"))
+    if (!col %in% names(squad_out)) squad_out[[col]] <- NA_real_
 
-bt <- as.data.table(read_parquet(file.path(cache_dir, "wc2026_bt_ratings.parquet")))
-strength <- merge(strength, bt[, .(team, bt = rating)], by = "team", all.x = TRUE)
-strength <- merge(strength, sim[, .(team, p_champ)], by = "team", all.x = TRUE)
+  # --- Team strength = Σ_squad (expected_minutes_norm / 90) * player_metric.
+  # NA (unrated player) contributes 0 to the sum but stays in the squad headcount. ---
+  .wsum <- function(x, w) sum(w * data.table::fifelse(is.na(x), 0, x))
+  agg <- squad_out[, {
+    w <- expected_minutes_norm / 90
+    list(panna   = .wsum(panna,   w),
+         offense = .wsum(offense, w),
+         defense = .wsum(defense, w),
+         epr     = .wsum(epr,     w),
+         psr     = .wsum(psr,     w),
+         squad_n = .N,
+         n_rated = sum(!is.na(panna)))
+  }, by = team]
 
-# Per-category rank (1 = strongest). Defence already flipped so higher = better.
-for (m in c("panna", "offense", "defense", "epr", "psr", "elo", "bt", "p_champ")) {
-  strength[[paste0("rank_", m)]] <- frank(-strength[[m]], ties.method = "min")
-}
+  strength <- data.table(team = teams, group = unname(team_group[teams]))
+  strength <- merge(strength, agg[, .(team, panna, offense, defense, epr, psr)],
+                    by = "team", all.x = TRUE)
+  strength[, elo := vapply(teams, team_metric, numeric(1), base = "elo")]
+  for (m in c("panna", "offense", "defense", "epr", "psr", "elo"))
+    strength[[m]] <- round(strength[[m]], 4)
 
-# Tiento: composite team rating — computed HERE (pannaverse) instead of on ITG
-# (was inthegame-blog/football/wc-maps.js::computeTeamRating). A z-blend of the
-# headline metrics. Weights are HAND-SET — a deliberate, fairly even spread that
-# keeps a small PSR contribution. For reference, a ridge (alpha=0 cv.glmnet) of
-# historical goal margin on the standardized metric diffs suggested a more
-# panna/Elo-heavy split (panna 0.47 / elo 0.36 / epr 0.17 / psr 0.00, PSR
-# dropping out on a negative coef; derivation in data-raw/debug/keep/_tiento_weights.R),
-# but these chosen weights trade some of that for balance. Each metric is
-# z-scored across the 48 teams (NA -> 0), then weighted-summed. ITG reads this
-# `tiento` column directly instead of recomputing the blend in the browser.
-TIENTO_WEIGHTS <- c(panna = 0.40, epr = 0.20, elo = 0.30, psr = 0.10)
-.z_score <- function(v) {
-  m <- mean(v, na.rm = TRUE); s <- stats::sd(v, na.rm = TRUE)
-  if (is.na(s) || s == 0) rep(0, length(v)) else ifelse(is.na(v), 0, (v - m) / s)
-}
-strength[, tiento := rowSums(sapply(names(TIENTO_WEIGHTS),
-                  function(col) TIENTO_WEIGHTS[[col]] * .z_score(strength[[col]])))]
-strength[, rank_tiento := frank(-tiento, ties.method = "min")]
-
-setorder(strength, -p_champ)
-write_parquet(strength, file.path(cache_dir, "wc2026_team_strength.parquet"))
-message(sprintf("  wc2026_team_strength.parquet: %d teams (panna/offense/defense/epr/psr = squad minutes-weighted; elo/bt/p_champ + tiento)",
-                nrow(strength)))
-
-# 5c. Squad rows with player ratings ----
-# squad_out (one row per squad player, joined to career-trait panna + league-
-# centered seasonal PSR + latest weekly EPR) was already built in section 5 — the
-# team strength above is its minutes-weighted aggregate. Here we add the
-# authoritative club, set column order, and publish. Ratings stay NA when a
-# player has no rated club minutes (smaller leagues) — the blog renders a dash;
-# per [[feedback-no-silent-imputation]] we do NOT zero-fill the per-player rows.
-
-# Authoritative club per player: latest CLUB (non-international) appearance
-# in opta_lineups across every scraped competition — covers Saudi/MLS/
-# Liga MX/Argentina squads the ratings join can't reach (blog previously
-# shimmed these from Wikidata, stale ~40% of the time). club_last_seen lets
-# the blog grey out genuinely stale clubs (transfers, retirements).
-lu_club_path <- file.path(opta_data_dir(), "opta_lineups.parquet")
-if (file.exists(lu_club_path)) {
-  # build_team_expected_minutes()'s international list MINUS UEFA_Super_Cup
-  # (that's a club fixture — its appearances should count as club evidence
-  # here; harmless there because EM pre-filters to the national team's rows).
-  intl_comps <- c("World_Cup", "UEFA_WC_Qualifiers", "UEFA_Euros",
-                  "UEFA_Euro_Qualifiers", "UEFA_Nations_League",
-                  "Copa_America", "AFCON", "AFCON_Qualifiers",
-                  "CONCACAF_Gold_Cup", "AFC_Asian_Cup", "AFC_WC_Qualifiers",
-                  "Asian_Cup_Qualifiers", "Gulf_Cup_of_Nations",
-                  "CAF_WC_Qualifiers", "CONMEBOL_WC_Qualifiers",
-                  "Intl_Friendlies")
-  lu_club <- as.data.table(read_parquet(
-    lu_club_path,
-    col_select = c("player_id", "team_name", "match_date", "competition")))
-  lu_club <- lu_club[!competition %in% intl_comps &
-                     player_id %in% squad_out$player_id]
-  lu_club[, match_date := as.Date(substr(match_date, 1, 10))]
-  setorder(lu_club, player_id, -match_date)
-  club_latest <- lu_club[, .SD[1L], by = player_id][
-    , .(player_id, club_name = team_name, club_last_seen = match_date)]
-  squad_out <- merge(squad_out, club_latest, by = "player_id", all.x = TRUE)
-  n_club <- sum(!is.na(squad_out$club_name))
-  message(sprintf("  club_name resolved for %d/%d squad players (latest club appearance)",
-                  n_club, nrow(squad_out)))
-  # Loudness guards: a player_id-format or date-format drift upstream would
-  # otherwise ship 0 clubs (or arbitrary "latest" picks) behind a green run.
-  # Normal coverage is ~97%; a few unscraped-league players are expected.
-  if (n_club < 0.8 * nrow(squad_out)) {
-    warning(sprintf(paste(
-      "club_name coverage is %d/%d (<80%%) — check player_id/competition",
-      "drift between announced squads and opta_lineups"),
-      n_club, nrow(squad_out)), call. = FALSE, immediate. = TRUE)
+  # HARD STOP guards. Per [[feedback-no-silent-imputation]] a published rating must
+  # HALT on a structural failure, not ship partial/zeroed data. Two failure modes:
+  #   1. elo missing for a team — match-dataset property absent (name drift / no row).
+  #   2. a team has NO squad aggregate — its name didn't match the announced-squad
+  #      team_name, or it has no announced squad (would leave panna NA after the join).
+  # Plus a wholesale-zero tripwire: now that the aggregate sums NA->0, a squad
+  # rating-join failure surfaces as a metric that is 0 for (nearly) every team
+  # rather than the old all-NA symptom — catch that too.
+  elo_na <- strength$team[is.na(strength$elo)]
+  if (length(elo_na) > 0L) {
+    stop(sprintf("wc2026_team_strength: elo missing for %d team(s): %s — match-dataset name drift or missing WC row.",
+                 length(elo_na), paste(elo_na, collapse = ", ")), call. = FALSE)
   }
-  if (any(!is.na(squad_out$club_name) & is.na(squad_out$club_last_seen))) {
-    warning("club_name present with NA club_last_seen — match_date parse drift in opta_lineups",
+  squad_missing <- strength$team[is.na(strength$panna)]
+  if (length(squad_missing) > 0L) {
+    stop(sprintf("wc2026_team_strength: no squad aggregate for %d team(s): %s — announced-squad team_name mismatch vs the match dataset, or a missing announced squad. Fix the name mapping (or announced_squads.R) before publishing.",
+                 length(squad_missing), paste(squad_missing, collapse = ", ")), call. = FALSE)
+  }
+  for (mt in c("panna", "epr", "psr")) {
+    nz <- mean(strength[[mt]] != 0, na.rm = TRUE)
+    if (nz < 0.5) {
+      stop(sprintf("wc2026_team_strength: %s is zero for %.0f%% of teams — likely a squad rating-join failure (check seasonal_%s in cache-skills/06 or cache-opta/07, and the player_id join). Refusing to publish.",
+                   mt, 100 * (1 - nz), mt), call. = FALSE)
+    }
+  }
+
+  # Published convention: defence as positive = good (internal model has
+  # negative = good, since defense is "xG added to the opponent").
+  strength[, defense := -defense]
+
+  bt <- as.data.table(read_parquet(file.path(cache_dir, "wc2026_bt_ratings.parquet")))
+  strength <- merge(strength, bt[, .(team, bt = rating)], by = "team", all.x = TRUE)
+  strength <- merge(strength, sim[, .(team, p_champ)], by = "team", all.x = TRUE)
+
+  # Per-category rank (1 = strongest). Defence already flipped so higher = better.
+  for (m in c("panna", "offense", "defense", "epr", "psr", "elo", "bt", "p_champ")) {
+    strength[[paste0("rank_", m)]] <- frank(-strength[[m]], ties.method = "min")
+  }
+
+  # Tiento: composite team rating — computed HERE (pannaverse) instead of on ITG
+  # (was inthegame-blog/football/wc-maps.js::computeTeamRating). A z-blend of the
+  # headline metrics. Weights are HAND-SET — a deliberate, fairly even spread that
+  # keeps a small PSR contribution. For reference, a ridge (alpha=0 cv.glmnet) of
+  # historical goal margin on the standardized metric diffs suggested a more
+  # panna/Elo-heavy split (panna 0.47 / elo 0.36 / epr 0.17 / psr 0.00, PSR
+  # dropping out on a negative coef; derivation in data-raw/debug/keep/_tiento_weights.R),
+  # but these chosen weights trade some of that for balance. Each metric is
+  # z-scored across the 48 teams (NA -> 0), then weighted-summed. ITG reads this
+  # `tiento` column directly instead of recomputing the blend in the browser.
+  TIENTO_WEIGHTS <- c(panna = 0.40, epr = 0.20, elo = 0.30, psr = 0.10)
+  .z_score <- function(v) {
+    m <- mean(v, na.rm = TRUE); s <- stats::sd(v, na.rm = TRUE)
+    if (is.na(s) || s == 0) rep(0, length(v)) else ifelse(is.na(v), 0, (v - m) / s)
+  }
+  strength[, tiento := rowSums(sapply(names(TIENTO_WEIGHTS),
+                    function(col) TIENTO_WEIGHTS[[col]] * .z_score(strength[[col]])))]
+  strength[, rank_tiento := frank(-tiento, ties.method = "min")]
+
+  setorder(strength, -p_champ)
+  write_parquet(strength, file.path(cache_dir, "wc2026_team_strength.parquet"))
+  message(sprintf("  wc2026_team_strength.parquet: %d teams (panna/offense/defense/epr/psr = squad minutes-weighted; elo/bt/p_champ + tiento)",
+                  nrow(strength)))
+
+  # 5c. Squad rows with player ratings ----
+  # squad_out (one row per squad player, joined to career-trait panna + league-
+  # centered seasonal PSR + latest weekly EPR) was already built in section 5 — the
+  # team strength above is its minutes-weighted aggregate. Here we add the
+  # authoritative club, set column order, and publish. Ratings stay NA when a
+  # player has no rated club minutes (smaller leagues) — the blog renders a dash;
+  # per [[feedback-no-silent-imputation]] we do NOT zero-fill the per-player rows.
+
+  # Authoritative club per player: latest CLUB (non-international) appearance
+  # in opta_lineups across every scraped competition — covers Saudi/MLS/
+  # Liga MX/Argentina squads the ratings join can't reach (blog previously
+  # shimmed these from Wikidata, stale ~40% of the time). club_last_seen lets
+  # the blog grey out genuinely stale clubs (transfers, retirements).
+  lu_club_path <- file.path(opta_data_dir(), "opta_lineups.parquet")
+  if (file.exists(lu_club_path)) {
+    # build_team_expected_minutes()'s international list MINUS UEFA_Super_Cup
+    # (that's a club fixture — its appearances should count as club evidence
+    # here; harmless there because EM pre-filters to the national team's rows).
+    intl_comps <- c("World_Cup", "UEFA_WC_Qualifiers", "UEFA_Euros",
+                    "UEFA_Euro_Qualifiers", "UEFA_Nations_League",
+                    "Copa_America", "AFCON", "AFCON_Qualifiers",
+                    "CONCACAF_Gold_Cup", "AFC_Asian_Cup", "AFC_WC_Qualifiers",
+                    "Asian_Cup_Qualifiers", "Gulf_Cup_of_Nations",
+                    "CAF_WC_Qualifiers", "CONMEBOL_WC_Qualifiers",
+                    "Intl_Friendlies")
+    lu_club <- as.data.table(read_parquet(
+      lu_club_path,
+      col_select = c("player_id", "team_name", "match_date", "competition")))
+    lu_club <- lu_club[!competition %in% intl_comps &
+                       player_id %in% squad_out$player_id]
+    lu_club[, match_date := as.Date(substr(match_date, 1, 10))]
+    setorder(lu_club, player_id, -match_date)
+    club_latest <- lu_club[, .SD[1L], by = player_id][
+      , .(player_id, club_name = team_name, club_last_seen = match_date)]
+    squad_out <- merge(squad_out, club_latest, by = "player_id", all.x = TRUE)
+    n_club <- sum(!is.na(squad_out$club_name))
+    message(sprintf("  club_name resolved for %d/%d squad players (latest club appearance)",
+                    n_club, nrow(squad_out)))
+    # Loudness guards: a player_id-format or date-format drift upstream would
+    # otherwise ship 0 clubs (or arbitrary "latest" picks) behind a green run.
+    # Normal coverage is ~97%; a few unscraped-league players are expected.
+    if (n_club < 0.8 * nrow(squad_out)) {
+      warning(sprintf(paste(
+        "club_name coverage is %d/%d (<80%%) — check player_id/competition",
+        "drift between announced squads and opta_lineups"),
+        n_club, nrow(squad_out)), call. = FALSE, immediate. = TRUE)
+    }
+    if (any(!is.na(squad_out$club_name) & is.na(squad_out$club_last_seen))) {
+      warning("club_name present with NA club_last_seen — match_date parse drift in opta_lineups",
+              call. = FALSE, immediate. = TRUE)
+    }
+    # Tripwire for an international comp missing from the exclusion blacklist:
+    # the symptom is a national team reported as someone's club.
+    nat_as_club <- intersect(unique(squad_out$club_name), groups$team)
+    if (length(nat_as_club) > 0L) {
+      warning("national team(s) resolved as club_name (intl_comps blacklist miss?): ",
+              paste(nat_as_club, collapse = ", "), call. = FALSE, immediate. = TRUE)
+    }
+  } else {
+    squad_out[, `:=`(club_name = NA_character_, club_last_seen = as.Date(NA))]
+    warning("opta_lineups.parquet not found — wc2026_squads.parquet ships without club_name",
             call. = FALSE, immediate. = TRUE)
   }
-  # Tripwire for an international comp missing from the exclusion blacklist:
-  # the symptom is a national team reported as someone's club.
-  nat_as_club <- intersect(unique(squad_out$club_name), groups$team)
-  if (length(nat_as_club) > 0L) {
-    warning("national team(s) resolved as club_name (intl_comps blacklist miss?): ",
-            paste(nat_as_club, collapse = ", "), call. = FALSE, immediate. = TRUE)
-  }
-} else {
-  squad_out[, `:=`(club_name = NA_character_, club_last_seen = as.Date(NA))]
-  warning("opta_lineups.parquet not found — wc2026_squads.parquet ships without club_name",
-          call. = FALSE, immediate. = TRUE)
-}
 
-setcolorder(squad_out, c("team", "group", "player_id", "player_name", "position",
-                         "club_name", "club_last_seen",
-                         "expected_minutes_norm", "is_starter_pred",
-                         "panna", "offense", "defense", "epr", "psr", "total_minutes"))
-setorder(squad_out, team, -expected_minutes_norm)
-write_parquet(squad_out, file.path(cache_dir, "wc2026_squads.parquet"))
-message(sprintf("  wc2026_squads.parquet: %d players across %d squads (%d with panna ratings)",
-                nrow(squad_out), uniqueN(squad_out$team), sum(!is.na(squad_out$panna))))
+  setcolorder(squad_out, c("team", "group", "player_id", "player_name", "position",
+                           "club_name", "club_last_seen",
+                           "expected_minutes_norm", "is_starter_pred",
+                           "panna", "offense", "defense", "epr", "psr", "total_minutes"))
+  setorder(squad_out, team, -expected_minutes_norm)
+  write_parquet(squad_out, file.path(cache_dir, "wc2026_squads.parquet"))
+  message(sprintf("  wc2026_squads.parquet: %d players across %d squads (%d with panna ratings)",
+                  nrow(squad_out), uniqueN(squad_out$team), sum(!is.na(squad_out$panna))))
+} else {
+  message(sprintf(paste0(
+    "\n[%s] Step 11 outputs not found in %s -- skipping simulation/groups/\n",
+    "  team-strength/squad exports (sections 3-5c: wc2026_simulation.parquet,\n",
+    "  wc2026_groups.parquet, wc2026_team_strength.parquet,\n",
+    "  wc2026_squads.parquet). Match predictions (section 2/2b) are\n",
+    "  unaffected. Whatever these four files last held (from a previous\n",
+    "  step-11 run, or nothing on a cache that never ran it) is left as-is."),
+    format(Sys.time(), "%H:%M:%S"), cache_dir))
+}
 
 # 6. Stamp shared build_id + save CSV companions for the small published tables ----
 # Per feedback 2026-05-28: small tables (<100KB / <10k rows) get a CSV
@@ -438,7 +473,12 @@ for (p in wc_parquets) {
             call. = FALSE, immediate. = TRUE)
     next
   }
-  dt <- as.data.table(read_parquet(pp))
+  # mmap = FALSE: this reads pp and immediately overwrites the same path.
+  # A memory-mapped read leaves the file handle open under it on Windows,
+  # so write_parquet() below fails with "a file with a user-mapped section
+  # open" (error 1224) -- the same reason section 3 already reads
+  # wc2026_simulation.parquet with mmap = FALSE.
+  dt <- as.data.table(read_parquet(pp, mmap = FALSE))
   dt[, build_id := .build_id_val]
   write_parquet(dt, pp)
   cp <- sub("\\.parquet$", ".csv", pp)
@@ -477,4 +517,12 @@ message("\n=== WC 2026 blog export complete ===")
 # qualifying → Elo > 1550; top 8 by champ% should include >=6 perennial
 # favourites; etc.). When a fact fails, either the pipeline regressed
 # OR a fact itself is stale and needs updating — both worth attention.
-run_wc2026_reference_checks(cache_dir)
+#
+# Gated on the same .wc11_available flag as sections 3-5c: it validates
+# simulation output specifically, so there is nothing to check when this run
+# didn't (re)produce one.
+if (.wc11_available) {
+  run_wc2026_reference_checks(cache_dir)
+} else {
+  message("  Skipping WC2026 reference-fact validation -- no simulation output this run.")
+}

--- a/data-raw/match-predictions-opta/12_export_wc2026_blog.R
+++ b/data-raw/match-predictions-opta/12_export_wc2026_blog.R
@@ -150,10 +150,19 @@ if (.n26 != nrow(wc_pred)) {
 # step 11 last wrote -- harmless. This flag exists for the other case: a
 # cache that never ran step 11 at all (a fresh clone, or a standalone step-12
 # run before 2026-06-11), where these files are absent outright.
-.wc11_sim_path <- file.path(cache_dir, "wc2026_simulation.parquet")
-.wc11_grp_path <- file.path(cache_dir, "wc2026_group_expectations.parquet")
-.wc11_bt_path  <- file.path(cache_dir, "wc2026_bt_ratings.parquet")
-.wc11_available <- all(file.exists(c(.wc11_sim_path, .wc11_grp_path, .wc11_bt_path)))
+.wc11_paths <- file.path(cache_dir, c("wc2026_simulation.parquet",
+                                      "wc2026_group_expectations.parquet",
+                                      "wc2026_bt_ratings.parquet"))
+# Presence is NOT enough, and the difference is not theoretical. Step 11
+# writes wc2026_bt_ratings.parquet BEFORE simulate_world_cup() and the other
+# two AFTER, so a failure inside the simulation leaves a fresh bt file beside
+# stale sim files with all three present -- and section 5 below would merge
+# the two vintages into one published wc2026_team_strength.parquet. Step 11
+# has been non-fatal since panna#194, so that is a routine event, not a rare
+# one. Require step 11's commit marker, which it deletes on entry and writes
+# only after all three files are on disk.
+.wc11_marker <- file.path(cache_dir, ".wc11_outputs_complete")
+.wc11_available <- all(file.exists(.wc11_paths)) && file.exists(.wc11_marker)
 
 if (.wc11_available) {
   # 3. Simulation — per-team round/champion probabilities ----
@@ -435,7 +444,7 @@ if (.wc11_available) {
                   nrow(squad_out), uniqueN(squad_out$team), sum(!is.na(squad_out$panna))))
 } else {
   message(sprintf(paste0(
-    "\n[%s] Step 11 outputs not found in %s -- skipping simulation/groups/\n",
+    "\n[%s] No complete step-11 output set in %s -- skipping simulation/groups/\n",
     "  team-strength/squad exports (sections 3-5c: wc2026_simulation.parquet,\n",
     "  wc2026_groups.parquet, wc2026_team_strength.parquet,\n",
     "  wc2026_squads.parquet). Match predictions (section 2/2b) are\n",
@@ -457,13 +466,23 @@ if (.wc11_available) {
 # this column when present to detect a torn mix of vintages; kept additive --
 # no reader currently requires it.
 .build_id_val <- .vb_generation_stamp()
+# Only files THIS run produced. build_id is a per-run stamp
+# (.vb_generation_stamp() is wall-clock + run id, not a data vintage), so
+# stamping a file the run did not rewrite asserts a freshness that isn't
+# there -- and worse, hands two genuinely different vintages the same id,
+# erasing the signal the blog's detectMixedBuild() reads. When sections
+# 3-5c are skipped, their outputs keep whatever build_id they were last
+# published with, which is the honest answer: they ARE from an earlier run.
 wc_parquets <- c("wc2026_predictions.parquet",
-                 "wc_history_predictions.parquet",
-                 "wc2026_simulation.parquet",
-                 "wc2026_groups.parquet",
-                 "wc2026_team_strength.parquet",
-                 "wc2026_squads.parquet",
-                 "wc2026_knockout_probs.parquet")
+                 "wc_history_predictions.parquet")
+if (.wc11_available) {
+  wc_parquets <- c(wc_parquets,
+                   "wc2026_simulation.parquet",
+                   "wc2026_groups.parquet",
+                   "wc2026_team_strength.parquet",
+                   "wc2026_squads.parquet",
+                   "wc2026_knockout_probs.parquet")
+}
 for (p in wc_parquets) {
   pp <- file.path(cache_dir, p)
   if (!file.exists(pp)) {

--- a/data-raw/match-predictions-opta/run_predictions_opta.R
+++ b/data-raw/match-predictions-opta/run_predictions_opta.R
@@ -363,10 +363,11 @@ step_results[["10d"]] <- run_pipeline_step("export_shootout_wpa", "10d", functio
   source("data-raw/match-predictions-opta/10d_export_shootout_wpa.R", local = TRUE)
 })
 
-# 14c-bis. World Cup liveness gate (steps 11/12/12b/12c) ----
-# Steps 11-12c simulate a tournament that is still being played. Once the
-# final is done there is nothing left to simulate, and the WC branch does not
-# just become pointless -- it becomes wrong, then it becomes fatal:
+# 14c-bis. World Cup liveness gate (steps 11/12b/12c) ----
+# Steps 11, 12b and 12c simulate/snapshot a tournament that is still being
+# played. Once the final is done there is nothing left to simulate, and the
+# WC branch does not just become pointless -- it becomes wrong, then it
+# becomes fatal:
 #
 #   * Pointless: step 11 filters predictions to WC2026 and, post-final, got
 #     zero rows. It went on to fit Bradley-Terry ratings and simulate 10,000
@@ -381,6 +382,17 @@ step_results[["10d"]] <- run_pipeline_step("export_shootout_wpa", "10d", functio
 #     aborted on Argentina. The guard is correct; the branch should not have
 #     been running at all.
 #
+# step 12 is deliberately NOT in this gate (it was, and that was the bug --
+# panna#194 review). Step 12 EXPORTS; it does not simulate. Half of it
+# (sections 2/2b of 12_export_wc2026_blog.R) reads only 07_predictions.rds
+# and is exactly as valid post-tournament as pre- -- wc2026_predictions.parquet
+# and wc_history_predictions.parquet are how the blog browses a FINISHED World
+# Cup. The other half reads step 11's outputs and stops running the moment
+# step 11 does (12_export_wc2026_blog.R gates those sections itself, on
+# whether wc2026_simulation.parquet et al. exist -- not on tournament
+# liveness), so disabling step 12 here bought no safety and cost the blog its
+# post-final match-history export.
+#
 # Decide from the data, not the calendar: any WC2026 row still marked
 # "fixture" means matches remain. 07_predictions.rds is the right source --
 # small (~53k x 15), already written by step 7, and it carries the played /
@@ -394,7 +406,7 @@ step_results[["10d"]] <- run_pipeline_step("export_shootout_wpa", "10d", functio
 # the WC steps for those runs, resuming by itself once the draw lands. These steps are idempotent weekly refreshes, so a skipped
 # run costs a stale WC tab for a day -- against eight days of the whole
 # pipeline publishing nothing, which is what the alternative cost.
-.wc_steps <- c("step_11_simulate_wc2026", "step_12_export_wc2026_blog",
+.wc_steps <- c("step_11_simulate_wc2026",
                "step_12b_snapshot_wc_minutes", "step_12c_snapshot_wc_strength")
 if (any(vapply(.wc_steps, function(k) isTRUE(run_steps[[k]]), logical(1)))) {
   .wc_remaining <- .wc2026_fixtures_remaining(cache_dir)
@@ -402,19 +414,21 @@ if (any(vapply(.wc_steps, function(k) isTRUE(run_steps[[k]]), logical(1)))) {
   # TRUE is the same failure shape as the bug above: it looks like it worked.
   if (is.na(.wc_remaining)) {
     message(sprintf(
-      "\n[%s] WC2026 gate: cannot read %s -- leaving steps 11/12/12b/12c as configured.",
+      "\n[%s] WC2026 gate: cannot read %s -- leaving steps 11/12b/12c as configured.",
       format(Sys.time(), "%H:%M:%S"),
       file.path(cache_dir, "07_predictions.rds")))
   } else if (.wc_remaining > 0L) {
     message(sprintf(
-      "\n[%s] WC2026 gate: %d fixture(s) remaining -- steps 11/12/12b/12c will run.",
+      "\n[%s] WC2026 gate: %d fixture(s) remaining -- steps 11/12b/12c will run.",
       format(Sys.time(), "%H:%M:%S"), .wc_remaining))
   } else {
     message(sprintf(paste0(
       "\n[%s] WC2026 gate: 0 unplayed WC2026 fixtures in 07_predictions.rds.\n",
-      "  The tournament is over -- DISABLING steps 11/12/12b/12c for this run.\n",
+      "  The tournament is over -- DISABLING steps 11/12b/12c for this run.\n",
       "  (Simulating a finished tournament produced champion odds off zero\n",
-      "  group-stage predictions, and aborts in build_knockout_lookup().)"),
+      "  group-stage predictions, and aborts in build_knockout_lookup().)\n",
+      "  Step 12 still runs -- it exports match history/predictions, not a\n",
+      "  simulation, and its own step-11-dependent sections self-skip."),
       format(Sys.time(), "%H:%M:%S")))
     for (.k in .wc_steps) run_steps[[.k]] <- FALSE
   }

--- a/tests/testthat/test-versebus.R
+++ b/tests/testthat/test-versebus.R
@@ -62,11 +62,15 @@ test_that("vb_download sha mismatch vs manifest warns and trusts the download wh
   # A manifest sha256 mismatch is far more often a stale manifest (upload
   # succeeded, the LAST manifest publish didn't) than real corruption --
   # vb_download() downgrades this to a warning and falls back to
-  # verify-by-size against a live listing. "No listing contradicts it" means
-  # the listing call SUCCEEDS but the asset isn't in it (panna#187 fix 2:
-  # a failed listing CALL is no longer treated the same way -- it now raises
-  # vb_error_transient instead of silently skipping the check, see the
-  # dedicated regression test below).
+  # verify-by-size against a live listing. With no listing available here
+  # (no gh::gh mock -- vb_list_assets fails, caught, treated as
+  # "can't corroborate either way"), the download is trusted and completes.
+  #
+  # This is the CONTRACT, not an accident. panna#187's second fix originally
+  # made a failed listing abort; that bricks the asset on an API blip, which
+  # is what this fallback exists to prevent. bouncer shipped it, CI caught
+  # it, and it was reverted (bouncerverse/bouncer 5edd3ac). Only the silence
+  # was fixed -- see the warning regression test below.
   dir <- withr::local_tempdir()
   dest <- file.path(dir, "model.parquet")
   writeLines("PRIOR-GOOD-CONTENT", dest)
@@ -84,12 +88,6 @@ test_that("vb_download sha mismatch vs manifest warns and trusts the download wh
       invisible(NULL)
     },
     .package = "piggyback"
-  )
-  testthat::local_mocked_bindings(
-    gh = function(...) list(assets = list(
-      list(name = "unrelated.parquet", size = 1, updated_at = "2026-01-01T00:00:00Z", id = 1)
-    )),
-    .package = "gh"
   )
 
   expect_warning(
@@ -296,7 +294,11 @@ test_that("vb_read_manifest retry classifies a transient listing error as transi
   expect_identical(call_n, 2L)  # confirms the retry branch actually ran
 })
 
-test_that("vb_download's verify_by_size raises when the listing call fails, instead of skipping the check (regression: unmanifested asset moved into place + .sha256 sidecar written with zero verification)", {
+test_that("vb_download's verify_by_size WARNS when the listing call fails, and says the file was accepted unverified", {
+  # The defect was silence, not the fallback. Trusting an unverifiable
+  # download is deliberate (see the sha-mismatch test above); doing it
+  # without saying so is not. Aborting instead would brick the asset on any
+  # transient API failure -- bouncer tried that and reverted it in 5edd3ac.
   dir <- withr::local_tempdir()
   dest <- file.path(dir, "unmanifested.rds")
 
@@ -313,18 +315,18 @@ test_that("vb_download's verify_by_size raises when the listing call fails, inst
     .package = "gh"
   )
 
-  # No manifest entry for this asset (the common, unmanifested-tag case) --
-  # verify_by_size() is the ONLY integrity check on this path.
-  expect_error(
-    suppressWarnings(
-      vb_download(repo = "test/fixture", tag = "verify-size-tag",
-                 name = "unmanifested.rds", dest = dest,
-                 manifest = list(assets = NULL))
-    ),
-    class = "vb_error_transient"
+  # No manifest entry (the common, unmanifested-tag case) -- verify_by_size()
+  # is the ONLY integrity check on this path, so its inability to run must be
+  # audible.
+  expect_warning(
+    vb_download(repo = "test/fixture", tag = "verify-size-tag",
+                name = "unmanifested.rds", dest = dest,
+                manifest = list(assets = NULL)),
+    "WITHOUT verification"
   )
-  # And the file must NOT have been moved into place unverified.
-  expect_false(file.exists(dest))
+  # Behaviour preserved: the download still completes.
+  expect_true(file.exists(dest))
+  expect_true(file.exists(paste0(dest, ".sha256")))
 })
 
 test_that("vb_publish's cache-invalidation hook failure is surfaced as a warning, never swallowed (regression: consumers served pre-publish data indefinitely with nothing recording why)", {

--- a/tests/testthat/test-versebus.R
+++ b/tests/testthat/test-versebus.R
@@ -62,9 +62,11 @@ test_that("vb_download sha mismatch vs manifest warns and trusts the download wh
   # A manifest sha256 mismatch is far more often a stale manifest (upload
   # succeeded, the LAST manifest publish didn't) than real corruption --
   # vb_download() downgrades this to a warning and falls back to
-  # verify-by-size against a live listing. With no listing available here
-  # (no gh::gh mock -- vb_list_assets fails, caught, treated as
-  # "can't corroborate either way"), the download is trusted and completes.
+  # verify-by-size against a live listing. "No listing contradicts it" means
+  # the listing call SUCCEEDS but the asset isn't in it (panna#187 fix 2:
+  # a failed listing CALL is no longer treated the same way -- it now raises
+  # vb_error_transient instead of silently skipping the check, see the
+  # dedicated regression test below).
   dir <- withr::local_tempdir()
   dest <- file.path(dir, "model.parquet")
   writeLines("PRIOR-GOOD-CONTENT", dest)
@@ -82,6 +84,12 @@ test_that("vb_download sha mismatch vs manifest warns and trusts the download wh
       invisible(NULL)
     },
     .package = "piggyback"
+  )
+  testthat::local_mocked_bindings(
+    gh = function(...) list(assets = list(
+      list(name = "unrelated.parquet", size = 1, updated_at = "2026-01-01T00:00:00Z", id = 1)
+    )),
+    .package = "gh"
   )
 
   expect_warning(
@@ -240,4 +248,122 @@ test_that("manifest merge carries forward previous entries on partial publish", 
   merged <- .vb_merge_entries(prev, entries)
   nms <- vapply(merged, `[[`, character(1), "name")
   expect_setequal(nms, c("new.parquet", "old.parquet"))
+})
+
+# ---------------------------------------------------------------------------
+# panna#187: four defects found in bouncer's dev->main review, ported here
+# (panna/R/versebus.R was byte-identical to bouncer's pre-fix copy).
+# ---------------------------------------------------------------------------
+
+test_that("vb_read_manifest retry classifies a transient listing error as transient, never absent (regression: silently disabled sha256 verification for the rest of the session)", {
+  # Only the RETRY branch is under test here -- it fires when the session
+  # has previously seen a manifest for this tag AND the first attempt just
+  # found it (legitimately) missing from the listing. If the retry then hits
+  # a genuine network blip, the old code swallowed every error as "absent"
+  # and fell through to legacy mode -- a network hiccup silently disabled
+  # sha256 verification for the rest of the session, the exact inversion of
+  # this file's own rule that uncertain classification is transient, not
+  # absent.
+  repo <- "test/fixture"; tag <- "retry-regression-tag"
+  key <- paste0(repo, "@", tag)
+  seen_key <- paste0("seen_", key)
+  assign(seen_key, TRUE, envir = .vb_state)
+  withr::defer(rm(list = seen_key, envir = .vb_state))
+
+  testthat::local_mocked_bindings(Sys.sleep = function(...) invisible(NULL), .package = "base")
+
+  call_n <- 0L
+  testthat::local_mocked_bindings(
+    gh = function(...) {
+      call_n <<- call_n + 1L
+      if (call_n == 1L) {
+        # First attempt: listing succeeds, manifest genuinely not present.
+        list(assets = list(list(name = "other.parquet", size = 1,
+                                updated_at = "2026-01-01T00:00:00Z", id = 1)))
+      } else {
+        # Retry: the LISTING CALL ITSELF fails -- a transient blip, not a
+        # confirmed absence.
+        stop(simpleError("simulated network timeout on retry"))
+      }
+    },
+    .package = "gh"
+  )
+
+  expect_error(
+    vb_read_manifest(repo, tag, required = FALSE),
+    class = "vb_error_transient"
+  )
+  expect_identical(call_n, 2L)  # confirms the retry branch actually ran
+})
+
+test_that("vb_download's verify_by_size raises when the listing call fails, instead of skipping the check (regression: unmanifested asset moved into place + .sha256 sidecar written with zero verification)", {
+  dir <- withr::local_tempdir()
+  dest <- file.path(dir, "unmanifested.rds")
+
+  testthat::local_mocked_bindings(
+    pb_download = function(file, dest, repo, tag, overwrite = TRUE, ...) {
+      writeLines("some-content", file.path(dest, file))
+      invisible(NULL)
+    },
+    .package = "piggyback"
+  )
+  # Listing fails outright (not a 404) every time verify_by_size calls it.
+  testthat::local_mocked_bindings(
+    gh = function(...) stop(simpleError("simulated listing failure")),
+    .package = "gh"
+  )
+
+  # No manifest entry for this asset (the common, unmanifested-tag case) --
+  # verify_by_size() is the ONLY integrity check on this path.
+  expect_error(
+    suppressWarnings(
+      vb_download(repo = "test/fixture", tag = "verify-size-tag",
+                 name = "unmanifested.rds", dest = dest,
+                 manifest = list(assets = NULL))
+    ),
+    class = "vb_error_transient"
+  )
+  # And the file must NOT have been moved into place unverified.
+  expect_false(file.exists(dest))
+})
+
+test_that("vb_publish's cache-invalidation hook failure is surfaced as a warning, never swallowed (regression: consumers served pre-publish data indefinitely with nothing recording why)", {
+  dir <- withr::local_tempdir()
+  p <- write_fixture_file(dir, "hookfile.rds", content = "hook-test-content")
+  sz <- file.size(p)
+
+  testthat::local_mocked_bindings(
+    pb_upload = function(file, repo, tag, overwrite = TRUE, ...) invisible(NULL),
+    .package = "piggyback"
+  )
+  testthat::local_mocked_bindings(
+    gh = function(...) list(assets = list(
+      list(name = "hookfile.rds", size = sz, updated_at = "2026-01-01T00:00:00Z", id = 1)
+    )),
+    .package = "gh"
+  )
+  withr::local_options(list(versebus.on_publish = function(repo, tag) stop("hook boom")))
+
+  expect_warning(
+    vb_publish(p, repo = "test/fixture", tag = "hook-regression-tag",
+              carry_forward = FALSE, max_retries = 0),
+    "cache-invalidation hook failed"
+  )
+})
+
+test_that("vb_generation drops NA updated_at before max() instead of letting one malformed asset null the whole generation", {
+  # vb_list_assets() deliberately fills NA_character_ for an asset missing
+  # updated_at so ONE bad entry doesn't kill the whole listing -- but
+  # max(assets$updated_at) with no na.rm propagated that NA through,
+  # indistinguishable from the "no assets at all" case.
+  testthat::local_mocked_bindings(
+    gh = function(...) list(assets = list(
+      list(name = "a.parquet", size = 1, updated_at = "2026-01-01T00:00:00Z", id = 1),
+      list(name = "b.parquet", size = 1, updated_at = NULL, id = 2),  # malformed
+      list(name = "c.parquet", size = 1, updated_at = "2026-03-01T00:00:00Z", id = 3)
+    )),
+    .package = "gh"
+  )
+  gen <- vb_generation("test/fixture", "generation-na-tag")
+  expect_identical(gen, "2026-03-01T00:00:00Z")
 })

--- a/tests/testthat/test-wc2026-export.R
+++ b/tests/testthat/test-wc2026-export.R
@@ -111,3 +111,61 @@ test_that("step 12's .wc11_available flag requires all three step-11 outputs, no
   expect_false(file.exists(file.path(cache_dir, "wc2026_team_strength.parquet")))
   expect_false(file.exists(file.path(cache_dir, "wc2026_squads.parquet")))
 })
+
+
+test_that("all three step-11 files present but no commit marker is still 'not ready'", {
+  # The case file.exists() alone cannot see, and the one that actually bites.
+  # Step 11 writes wc2026_bt_ratings.parquet BEFORE simulate_world_cup() and
+  # the other two AFTER. If the simulation throws, the cache is left with a
+  # FRESH bt file beside STALE sim files -- all three present. Section 5 would
+  # then merge two vintages into one published wc2026_team_strength.parquet.
+  # Step 11 has been non-fatal since panna#194, so this is routine, not rare.
+  skip_if_not_installed("arrow")
+  local_no_reload()
+
+  script <- testthat::test_path("..", "..", "data-raw", "match-predictions-opta",
+                                "12_export_wc2026_blog.R")
+  skip_if_not(file.exists(script), "12_export_wc2026_blog.R not found")
+
+  cache_dir <- withr::local_tempdir()
+  saveRDS(.wc12_preds_fixture(), file.path(cache_dir, "07_predictions.rds"))
+  for (f in c("wc2026_simulation.parquet", "wc2026_group_expectations.parquet",
+              "wc2026_bt_ratings.parquet")) {
+    arrow::write_parquet(data.frame(team = "Mexico", p_champ = 0.01, rating = 1),
+                         file.path(cache_dir, f))
+  }
+  # No .wc11_outputs_complete marker: no single run produced this set.
+
+  expect_no_error(source(script, local = TRUE))
+  expect_true(file.exists(file.path(cache_dir, "wc2026_predictions.parquet")))
+  expect_false(file.exists(file.path(cache_dir, "wc2026_team_strength.parquet")))
+  expect_false(file.exists(file.path(cache_dir, "wc2026_squads.parquet")))
+})
+
+test_that("a skipped simulation is not re-stamped with this run's build_id", {
+  # build_id is a per-run stamp, not a data vintage. Stamping a file the run
+  # did not rewrite claims a freshness that isn't there, and gives two
+  # different vintages the same id -- which is exactly the signal the blog's
+  # detectMixedBuild() reads to spot a torn publish.
+  skip_if_not_installed("arrow")
+  local_no_reload()
+
+  script <- testthat::test_path("..", "..", "data-raw", "match-predictions-opta",
+                                "12_export_wc2026_blog.R")
+  skip_if_not(file.exists(script), "12_export_wc2026_blog.R not found")
+
+  cache_dir <- withr::local_tempdir()
+  saveRDS(.wc12_preds_fixture(), file.path(cache_dir, "07_predictions.rds"))
+  sim_path <- file.path(cache_dir, "wc2026_simulation.parquet")
+  arrow::write_parquet(data.frame(team = "Mexico", p_champ = 0.01,
+                                  build_id = "PRIOR-RUN"), sim_path)
+
+  expect_no_error(source(script, local = TRUE))
+
+  # Untouched: same build_id it went in with.
+  expect_identical(arrow::read_parquet(sim_path)$build_id, "PRIOR-RUN")
+  # And the files this run DID write carry a real stamp.
+  fresh <- arrow::read_parquet(file.path(cache_dir, "wc2026_predictions.parquet"))
+  expect_true("build_id" %in% names(fresh))
+  expect_false(any(fresh$build_id == "PRIOR-RUN"))
+})

--- a/tests/testthat/test-wc2026-export.R
+++ b/tests/testthat/test-wc2026-export.R
@@ -1,0 +1,113 @@
+# Tests for 12_export_wc2026_blog.R surviving an absent step-11 simulation.
+#
+# panna#194 (2026-08-21 regression, review fix): the WC2026 liveness gate in
+# run_predictions_opta.R disabled step 12 alongside steps 11/12b/12c once the
+# tournament ended. That was wrong -- step 12's sections 2/2b (match
+# predictions) read ONLY 07_predictions.rds and are exactly as valid
+# post-tournament as pre- (they're how the blog browses a finished World
+# Cup). Only sections 3, 4, 5 and 5c read step 11's outputs
+# (wc2026_simulation.parquet, wc2026_group_expectations.parquet,
+# wc2026_bt_ratings.parquet) directly, via bare read_parquet() calls that
+# hard-error if those files are absent.
+#
+# The fix: step 12 stays enabled always; 12_export_wc2026_blog.R itself now
+# computes a `.wc11_available` flag from whether step 11's three output files
+# exist, and gates sections 3-5c and 8 on that flag instead of ever hard-
+# erroring. This test proves the absent-simulation path: with only
+# 07_predictions.rds in the cache (no wc2026_simulation.parquet et al.),
+# sourcing the step must not error, must still publish the match-prediction
+# exports, and must NOT publish the step-11-dependent ones.
+#
+# local_no_reload() stubs devtools::load_all() before sourcing the script --
+# see test-publish-gating.R's copy of this helper for the full rationale
+# (the script's own load_all() header reloads the package namespace
+# mid-suite, discarding this test's mocks and breaking every test file that
+# runs after it). Defined again here rather than shared across files because
+# testthat does not guarantee one test file's top-level helpers are visible
+# to another's.
+local_no_reload <- function(env = parent.frame()) {
+  if (!requireNamespace("devtools", quietly = TRUE)) return(invisible(NULL))
+  testthat::local_mocked_bindings(
+    load_all = function(...) invisible(NULL),
+    .package = "devtools",
+    .env = env
+  )
+}
+
+.wc12_preds_fixture <- function() {
+  data.frame(
+    league = WC2026_LEAGUE,
+    season = WC2026_SEASON_LABEL,
+    match_date = as.Date("2026-06-15") + 0:1,
+    home_team = c("Mexico", "Czechia"),
+    away_team = c("Czechia", "Mexico"),
+    prob_H = c(0.45, 0.30),
+    prob_D = c(0.30, 0.35),
+    prob_A = c(0.25, 0.35),
+    pred_home_goals = c(1.6, 1.1),
+    pred_away_goals = c(1.0, 1.4),
+    predicted_result = c("H", "A"),
+    stringsAsFactors = FALSE
+  )
+}
+
+test_that("step 12 exports match predictions when step 11 has not run", {
+  skip_if_not_installed("arrow")
+  local_no_reload()
+
+  script <- testthat::test_path("..", "..", "data-raw", "match-predictions-opta",
+                                "12_export_wc2026_blog.R")
+  skip_if_not(file.exists(script), "12_export_wc2026_blog.R not found")
+
+  cache_dir <- withr::local_tempdir()
+  saveRDS(.wc12_preds_fixture(), file.path(cache_dir, "07_predictions.rds"))
+  # Deliberately absent: wc2026_simulation.parquet, wc2026_group_expectations.
+  # parquet, wc2026_bt_ratings.parquet -- exactly the state step 11 leaves a
+  # cache in when it has never run (or, before this fix, when the liveness
+  # gate disabled it).
+
+  expect_no_error(source(script, local = TRUE))
+
+  # Step-11-INdependent exports: must be written.
+  expect_true(file.exists(file.path(cache_dir, "wc2026_predictions.parquet")))
+  expect_true(file.exists(file.path(cache_dir, "wc_history_predictions.parquet")))
+
+  preds <- arrow::read_parquet(file.path(cache_dir, "wc2026_predictions.parquet"))
+  expect_equal(nrow(preds), 2L)
+  expect_setequal(preds$home_team, c("Mexico", "Czechia"))
+
+  hist <- arrow::read_parquet(file.path(cache_dir, "wc_history_predictions.parquet"))
+  expect_equal(nrow(hist), 2L)
+
+  # Step-11-dependent exports: must NOT be written -- there is nothing to
+  # publish, and (pre-fix) getting here at all meant the script had already
+  # hard-errored on a missing wc2026_simulation.parquet.
+  expect_false(file.exists(file.path(cache_dir, "wc2026_simulation.parquet")))
+  expect_false(file.exists(file.path(cache_dir, "wc2026_groups.parquet")))
+  expect_false(file.exists(file.path(cache_dir, "wc2026_team_strength.parquet")))
+  expect_false(file.exists(file.path(cache_dir, "wc2026_squads.parquet")))
+})
+
+test_that("step 12's .wc11_available flag requires all three step-11 outputs, not just one", {
+  skip_if_not_installed("arrow")
+  local_no_reload()
+
+  script <- testthat::test_path("..", "..", "data-raw", "match-predictions-opta",
+                                "12_export_wc2026_blog.R")
+  skip_if_not(file.exists(script), "12_export_wc2026_blog.R not found")
+
+  cache_dir <- withr::local_tempdir()
+  saveRDS(.wc12_preds_fixture(), file.path(cache_dir, "07_predictions.rds"))
+  # Only ONE of the three step-11 outputs present (a torn/partial step-11
+  # run) -- must still be treated as unavailable, not spuriously "ready".
+  arrow::write_parquet(data.frame(team = "Mexico", p_champ = 0.01),
+                       file.path(cache_dir, "wc2026_simulation.parquet"))
+
+  expect_no_error(source(script, local = TRUE))
+  expect_true(file.exists(file.path(cache_dir, "wc2026_predictions.parquet")))
+  # wc2026_simulation.parquet exists going in, but section 3 must not have
+  # re-run against a partial step-11 output (no wc2026_team_strength.parquet,
+  # which only section 5 -- gated on the same flag -- would produce).
+  expect_false(file.exists(file.path(cache_dir, "wc2026_team_strength.parquet")))
+  expect_false(file.exists(file.path(cache_dir, "wc2026_squads.parquet")))
+})


### PR DESCRIPTION
Two pieces. The first fixes a regression I introduced in #194 that made a live blog bug permanent; the second is the panna leg of the cross-repo `versebus` work in #187.

## Piece 1 — the World Cup export was frozen, permanently (#180)

#194's liveness gate disabled steps 11/12/12b/12c together once the tournament ended. **Step 12 should never have been on that list: it exports, it does not simulate.** Its two prediction exports read only `07_predictions.rds` and are exactly as valid post-tournament as pre — they are how the blog browses a *finished* World Cup.

Live consequence, verified on `blog-latest`: `wc2026_predictions.parquet` was **0 rows** (140-byte header-only CSV) and `wc_history_predictions.parquet` had **192 rows covering 2014/2018/2022 with 2026 missing**. Both were empty because of the separate `val`-split bug (#191). That is now fixed and yesterday's pipeline run restored **104 WC 2026 rows** to `07_predictions.rds` — but with step 12 gated off, they could never reach the blog.

- Step 12 is out of `.wc_steps` and runs on every pipeline run. Steps 11/12b/12c stay gated — they simulate, or snapshot a simulation in progress.
- `12_export_wc2026_blog.R` gates only sections 3/4/5/5c and 8 — the ones reading step 11's outputs — behind a `.wc11_available` flag, instead of hard-erroring on a bare `read_parquet()`.

### Then review found the gate wasn't enough

Step 11 writes `wc2026_bt_ratings.parquet` **before** `simulate_world_cup()` and the other two **after**. A failure inside the simulation leaves a *fresh* BT file beside *stale* simulation files with all three present — `file.exists()` passes, section 5 merges two vintages into one `wc2026_team_strength.parquet`, step 13 publishes it. Since #194 made step 11 non-fatal, that is now the routine case rather than one that halts the pipeline. Two individually-correct changes producing a third problem.

- **Step 11 writes a commit marker**, deleted on entry and written only after all three outputs land. `file.exists()` answers "are there files"; the question is "did one run produce this whole set".
- **`build_id` only stamps files the run actually wrote.** `.vb_generation_stamp()` is wall-clock plus run id, so stamping an untouched file claims a freshness that isn't there — and gives two different vintages the same id, erasing the signal the blog's `detectMixedBuild()` reads.

Post-tournament the World Cup pages will now show "mixed data build", correctly: predictions refresh while the simulation stays frozen at the final.

## Piece 2 — versebus (#187), with one fix corrected

Four defects, each turning a transient failure into a silently-accepted success. Three are straight ports. **The fourth was wrong, and had already been caught once.**

`bouncerverse/bouncer@5edd3ac` (2026-08-16) backed all four out and said why:

> `verify_by_size()` swallowing a listing failure is NOT simply a bug: the sha-mismatch caller deliberately falls back to it... Aborting there would brick an asset on any API blip. Had this ridden in on a green build I would have shipped a behaviour change dressed as a bug fix.

The code agrees at the caller: a manifest sha mismatch is far more often a stale manifest than corruption, so it warns and falls back to `verify_by_size()` because *"a hard abort would permanently brick the asset until someone manually republishes the manifest."*

So the fix keeps the behaviour and removes only the silence — it now warns, naming the file and stating it was accepted **without** verification.

**The tell was in the diff**: the port had to rewrite a pre-existing test to accommodate the change, deleting a comment documenting the contract verbatim. A change that needs an existing test's intent rewritten is a behaviour change, not a bug fix. That test is restored with a comment recording why it must not be "fixed" again.

## Verification

- **Full suite: 7,859 pass, 0 fail, 0 error.**
- `test-versebus-sync.R` (which compares against torp's canonical copy) passes 25/0 — torp has the identical correction, committed on its `dev`.
- Every guard mutation-tested: removing the step-11 marker requirement, stamping `build_id` unconditionally, and reverting `verify_by_size` to the silent swallow each fail their own test and nothing else.

## Review

`code-reviewer` and `silent-failure-hunter`, both Sonnet. The former came back clean; the latter found the step-11 provenance bug, which is fixed in `7f483d2`. The `verify_by_size` correction came from reading bouncer's history rather than from either reviewer.

## Not in this PR

Four other repos vendor `versebus.R` and still carry all four defects: `bouncer` itself (backed out pending exactly this coordinated change), `torpmodels`, `pannamodels`, `bouncermodels`. torp's own drift guard fails against `torpmodels` as a result. Tracked in #187, deliberately held back.

Also unchanged: `vb_publish()`'s hook failure is a `cli_warn`, which in an Actions log is one line among thousands and leaves the job green. Better than the silent `try()` it replaced, still weaker than this repo's standard — raised on #187 as a follow-up for both repos rather than diverging from bouncer here.

Refs #180, #187.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01533D7gX5RBR78vJbjFL4Yo