### PR TITLE
Export the match features, so the model's inputs stop being invisible

### DIFF
--- a/.github/workflows/predictions-pipeline.yml
+++ b/.github/workflows/predictions-pipeline.yml
@@ -274,6 +274,12 @@ jobs:
               # blog-latest (pannadata build-blog-data passes it to R2 as
               # football/shootout-wpa.parquet). Cheap (thin data) and additive;
               # absent for seasons with no shootouts in blog comps.
+              # Publish the per-fixture strength features the models consume.
+              # 04_match_dataset.rds is built on the runner and discarded, so
+              # without this there is no way to ask what the model saw for a
+              # given fixture outside a live run -- panna#190 and panna#192 both
+              # stalled on exactly that. Small, additive, no existing consumer.
+              step_04b_export_match_features = TRUE,
               step_10d_export_shootout_wpa   = TRUE,
               # WC2026 simulation + blog export. Refresh weekly with the rest
               # of the predictions chain so the WC tab tracks the latest match

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: panna
 Title: Player Rating System for Football Using RAPM, SPM, and EPV Methods
-Version: 0.3.25
+Version: 0.3.26
 Authors@R:
     person("Pete", "Owen", , "pete.owen1@hotmail.co.uk", role = c("aut", "cre", "cph"))
 Description: Implements player ratings for football (soccer) from 'Opta'

--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,14 @@ the actual goals, per fixture.
 * Not the whole match dataset: ~170 columns × 58k rows is a large asset to
   publish for a diagnostic, and the strength subset plus outcomes is what the
   open questions actually need.
+* **The step is non-fatal**, and the first version of it was not — a review
+  finding. It sits between steps 5 and 6, so a fatal wrapper there sets
+  `pipeline_failed` before steps 6, 7, 9, 10, 10b/c/d, 11–12c and 13, and
+  nothing publishes at all. Position is what makes fatal expensive, not
+  publish-safety. The likely trigger would have been this step's own
+  abort-on-empty-regex guard, fired by a feature rename upstream: a correct
+  guard taking the release down with it is the 2026-08-13 outage exactly, so
+  reintroducing it the same day it was fixed would have been careless.
 
 # panna 0.3.25 (dev)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,31 @@
+# panna 0.3.26 (dev)
+
+## The match dataset is no longer invisible from outside a pipeline run
+
+`04_match_dataset.rds` is built on the runner and thrown away. Nothing uploads
+it, so "what did the model actually see for this fixture?" has been
+unanswerable without a full local run — and step 02 loads a 5.9GB cache, so
+that is not a casual thing to do. Two investigations stalled on this in the
+same week, both saying so in as many words: #190 ("`04_match_dataset.rds` is a
+build artifact and is not available outside a pipeline run") and #192 ("the
+published `predictions.parquet` does not [carry actuals], which is why this
+issue stops at the symptom").
+
+New opt-in step **4b** writes `match_features.parquet` and registers it for
+`predictions-latest`: the identity columns, the team-strength features, and
+the actual goals, per fixture.
+
+* **The strength subset is defined by the same regex `07_predict_fixtures.R`
+  uses** for its degraded-features guard, deliberately duplicated rather than
+  reinvented. A diagnostic describing a different column set than the guard
+  inspects would send the next investigation somewhere the guard never looks.
+* **It aborts if that regex matches nothing**, rather than writing a valid
+  empty parquet and reporting SUCCESS — the "looks like it worked" shape this
+  pipeline has been bitten by repeatedly.
+* Not the whole match dataset: ~170 columns × 58k rows is a large asset to
+  publish for a diagnostic, and the strength subset plus outcomes is what the
+  open questions actually need.
+
 # panna 0.3.25 (dev)
 
 ## versebus: four silent-failure defects ported from bouncer's review (panna#187)

--- a/data-raw/match-predictions-opta/04b_export_match_features.R
+++ b/data-raw/match-predictions-opta/04b_export_match_features.R
@@ -1,0 +1,86 @@
+# 04b_export_match_features.R
+# Export the team-strength features the goals/outcome models actually consume,
+# per fixture, as a compact parquet.
+#
+# Why this exists: 04_match_dataset.rds is a build artifact. The GHA runner
+# creates it, uses it, and throws it away -- it is not uploaded anywhere. So
+# any question of the form "what did the model actually see for this fixture?"
+# is unanswerable outside a live pipeline run. Two separate investigations
+# stalled on exactly that in the same week (panna#190, panna#192, both of which
+# say so in as many words), and the second one needs these numbers to size a
+# shrinkage prior rather than guess at one.
+#
+# Deliberately NOT the whole match dataset: ~170 feature columns x 58k rows is
+# a large asset to publish for a diagnostic. This exports the identity columns,
+# the strength subset, and the outcome columns needed to calibrate against
+# actuals.
+#
+# Inputs:
+#   cache-predictions-opta/04_match_dataset.rds
+#   cache-predictions-opta/05_goals_model.rds   -- for feature_cols
+#
+# Outputs:
+#   cache-predictions-opta/match_features.parquet  (registered for
+#   predictions-latest; additive, no existing consumer reads it)
+
+suppressMessages({library(data.table); library(arrow)})
+
+md_path <- file.path(cache_dir, "04_match_dataset.rds")
+gm_path <- file.path(cache_dir, "05_goals_model.rds")
+stopifnot(file.exists(md_path))
+
+md <- as.data.table(readRDS(md_path))
+message(sprintf("  match dataset: %d rows x %d cols", nrow(md), ncol(md)))
+
+# The strength subset, defined EXACTLY as 07_predict_fixtures.R defines it for
+# its degraded-features guard. Same regex, deliberately -- a diagnostic that
+# describes a different set of columns than the guard inspects would send the
+# next investigation somewhere the guard never looks. If that regex changes,
+# this must change with it.
+feature_cols <- if (file.exists(gm_path)) readRDS(gm_path)$feature_cols else names(md)
+strength_cols <- unique(c(
+  grep("^(home|away)_elo$|^elo_diff$", feature_cols, value = TRUE),
+  grep("^(home|away)_(sum|avg|max|min|gk|stdev)_", feature_cols, value = TRUE),
+  grep("^(home|away)_sk_", feature_cols, value = TRUE),
+  grep("_diff$", feature_cols, value = TRUE)
+))
+strength_cols <- intersect(strength_cols, names(md))
+
+id_cols <- intersect(c("match_id", "match_date", "league", "season",
+                       "season_end_year", "split", "match_status",
+                       "home_team", "away_team", "home_team_id", "away_team_id",
+                       "home_goals", "away_goals", "home_xg", "away_xg"),
+                     names(md))
+
+out <- md[, c(id_cols, strength_cols), with = FALSE]
+message(sprintf("  exporting %d identity + %d strength column(s)",
+                length(id_cols), length(strength_cols)))
+
+# Assert the export is actually usable for the question it exists to answer:
+# a strength subset that came back empty would still write a valid parquet and
+# still look like a successful step.
+if (length(strength_cols) == 0L) {
+  stop("04b: no strength feature columns matched -- the regex and the match ",
+       "dataset have diverged. Fix before trusting any diagnostic built on this.",
+       call. = FALSE)
+}
+
+out_path <- file.path(cache_dir, "match_features.parquet")
+arrow::write_parquet(out, out_path)
+message(sprintf("  Written: %s (%d rows, %.1f MB)",
+                basename(out_path), nrow(out), file.size(out_path) / 1024^2))
+
+# Coverage summary in the log, so a run tells you whether the thing you came
+# for is present without downloading the asset first.
+if ("split" %in% names(out)) {
+  message("  rows by split: ",
+          paste(sprintf("%s=%d", names(table(out$split)), as.integer(table(out$split))),
+                collapse = ", "))
+}
+
+if (exists("publish_files", envir = .GlobalEnv)) {
+  publish_files$predictions_latest <<- c(publish_files$predictions_latest, out_path)
+  message("  Registered match_features.parquet for predictions-latest publish (step 13)")
+} else {
+  message("  (standalone run -- not registered for step-13 publish)")
+}

--- a/data-raw/match-predictions-opta/run_predictions_opta.R
+++ b/data-raw/match-predictions-opta/run_predictions_opta.R
@@ -53,6 +53,7 @@ if (!exists("run_steps", inherits = FALSE)) {
     step_02b_team_skill_features     = TRUE,   # Team-level skill aggregations
     step_03_team_rolling_features    = TRUE,
     step_04_build_match_dataset      = TRUE,
+    step_04b_export_match_features   = FALSE,  # Opt-in: publish the strength features per fixture (diagnostic)
     step_05_fit_goals_model          = TRUE,
     step_06_fit_outcome_model        = TRUE,
     step_07_predict_fixtures         = TRUE,
@@ -304,6 +305,22 @@ step_results[[5]] <- run_pipeline_step("fit_goals_model", 5, function() {
   source("data-raw/match-predictions-opta/05_fit_goals_model.R", local = TRUE)
 })
 check_pred_critical(step_results[[5]])
+
+# 8b. Step 4b: Export Match Features (diagnostic) ----
+# Runs AFTER step 5, not after step 4, because it reads 05_goals_model.rds for
+# the authoritative feature_cols. Numbered 4b because that is the artifact it
+# describes -- the step-04 match dataset -- and the number should say what the
+# thing is, not when it happens to run.
+#
+# Non-critical by construction: it reads caches and writes one parquet, so a
+# failure here says nothing about the predictions themselves. It still uses
+# run_pipeline_step (fatal) rather than the optional wrapper, because unlike
+# the World Cup branch it registers a file for publish, and a half-written
+# diagnostic reaching predictions-latest is worse than a red run.
+
+step_results[["4b"]] <- run_pipeline_step("export_match_features", "4b", function() {
+  source("data-raw/match-predictions-opta/04b_export_match_features.R", local = TRUE)
+})
 
 # 10. Step 6: Fit Outcome Model ----
 

--- a/data-raw/match-predictions-opta/run_predictions_opta.R
+++ b/data-raw/match-predictions-opta/run_predictions_opta.R
@@ -312,13 +312,23 @@ check_pred_critical(step_results[[5]])
 # describes -- the step-04 match dataset -- and the number should say what the
 # thing is, not when it happens to run.
 #
-# Non-critical by construction: it reads caches and writes one parquet, so a
-# failure here says nothing about the predictions themselves. It still uses
-# run_pipeline_step (fatal) rather than the optional wrapper, because unlike
-# the World Cup branch it registers a file for publish, and a half-written
-# diagnostic reaching predictions-latest is worse than a red run.
+# NON-FATAL, and the reasoning matters because the first version of this got it
+# wrong. It reads caches and writes one parquet, so a failure here says nothing
+# about the predictions -- but a fatal wrapper at THIS position sets
+# pipeline_failed before steps 6, 7, 9, 10, 10b/c/d, 11-12c and 13, so every
+# one of them prints "SKIPPED (previous step failed)" and nothing publishes at
+# all. Position is what makes fatal expensive here, not publish-safety: step 12
+# registers its files at the very end too, which is exactly why it is safe to
+# make non-fatal, and 4b registers at :83 after a successful write for the same
+# reason.
+#
+# The trigger would most likely be this step's OWN abort-on-empty-regex guard,
+# fired by a feature rename upstream. A correct guard taking the release down
+# with it is the 2026-08-13 outage repeated: build_knockout_lookup()'s
+# invariant was right, and it still cost eight days of publishing because a
+# side branch was allowed to be fatal.
 
-step_results[["4b"]] <- run_pipeline_step("export_match_features", "4b", function() {
+step_results[["4b"]] <- run_pred_step_optional("export_match_features", "4b", function() {
   source("data-raw/match-predictions-opta/04b_export_match_features.R", local = TRUE)
 })
 

--- a/tests/testthat/test-match-features-export.R
+++ b/tests/testthat/test-match-features-export.R
@@ -1,0 +1,108 @@
+# Tests for 04b_export_match_features.R.
+#
+# This step exists because 04_match_dataset.rds is a build artifact the GHA
+# runner discards, which left panna#190 and panna#192 both unable to check what
+# the model actually saw for a fixture. The value of the export is entirely in
+# WHICH columns it carries, so that is what these tests pin.
+
+local_no_reload <- function(env = parent.frame()) {
+  if (!requireNamespace("devtools", quietly = TRUE)) return(invisible(NULL))
+  testthat::local_mocked_bindings(
+    load_all = function(...) invisible(NULL), .package = "devtools", .env = env)
+}
+
+.mf_fixture <- function(dir) {
+  n <- 40L
+  md <- data.frame(
+    match_id = sprintf("m%03d", seq_len(n)), match_date = Sys.Date() + seq_len(n),
+    league = "ENG", season = "2026-2027", season_end_year = 2027L,
+    split = rep(c("train", "fixture"), length.out = n),
+    match_status = rep(c("Played", "Fixture"), length.out = n),
+    home_team = "A", away_team = "B",
+    home_goals = 1L, away_goals = 2L,
+    home_sum_panna = 1, away_sum_panna = 2,
+    home_elo = 1500, away_elo = 1400, elo_diff = 100, panna_diff = -1,
+    home_avg_psr = 0.5, away_avg_psr = 0.4,
+    diff_form = 0.1, some_other_col = 9,
+    stringsAsFactors = FALSE)
+  saveRDS(md, file.path(dir, "04_match_dataset.rds"))
+  saveRDS(list(feature_cols = c("home_sum_panna", "away_sum_panna", "home_elo",
+                                "away_elo", "elo_diff", "panna_diff",
+                                "home_avg_psr", "away_avg_psr", "diff_form",
+                                "some_other_col")),
+          file.path(dir, "05_goals_model.rds"))
+  dir
+}
+
+.run_04b <- function(cache_dir, publish = TRUE) {
+  script <- testthat::test_path("..", "..", "data-raw", "match-predictions-opta",
+                                "04b_export_match_features.R")
+  testthat::skip_if_not(file.exists(script), "04b script not found")
+  if (publish) {
+    assign("publish_files",
+           list(predictions_latest = character(0), blog_latest = character(0)),
+           envir = globalenv())
+  } else if (exists("publish_files", envir = globalenv())) {
+    rm("publish_files", envir = globalenv())
+  }
+  # The step must run inside a closure whose enclosing chain reaches globalenv,
+  # exactly as run_pipeline_step() wraps it -- that is what lets the script's
+  # `publish_files$... <<-` find the accumulator. Sourcing at top level instead
+  # makes `<<-` skip globalenv and error, so this test would prove nothing.
+  runner <- function() source(script, local = TRUE)
+  environment(runner) <- list2env(list(cache_dir = cache_dir, script = script),
+                                  parent = globalenv())
+  runner()
+  invisible(NULL)
+}
+
+test_that("04b exports the strength features and the actuals, and nothing else", {
+  skip_if_not_installed("arrow")
+  local_no_reload()
+  d <- .mf_fixture(withr::local_tempdir())
+  on.exit(suppressWarnings(rm("publish_files", envir = globalenv())), add = TRUE)
+
+  .run_04b(d)
+  out <- arrow::read_parquet(file.path(d, "match_features.parquet"))
+
+  expect_equal(nrow(out), 40L)
+  # Strength features: the whole point of the export.
+  expect_true(all(c("home_sum_panna", "away_sum_panna", "home_elo", "away_elo",
+                    "elo_diff", "panna_diff", "home_avg_psr", "away_avg_psr")
+                  %in% names(out)))
+  # Actuals: without these the export cannot be calibrated against outcomes,
+  # which is most of why panna#192 wanted it.
+  expect_true(all(c("home_goals", "away_goals") %in% names(out)))
+  # Identity: needed to join back to predictions.parquet on match_id.
+  expect_true(all(c("match_id", "league", "season", "split") %in% names(out)))
+  # A feature that is neither strength nor identity must not ride along --
+  # otherwise this quietly becomes a full match-dataset dump.
+  expect_false("some_other_col" %in% names(out))
+})
+
+test_that("04b registers exactly one file for publish, and only when asked", {
+  skip_if_not_installed("arrow")
+  local_no_reload()
+  d <- .mf_fixture(withr::local_tempdir())
+  on.exit(suppressWarnings(rm("publish_files", envir = globalenv())), add = TRUE)
+
+  .run_04b(d)
+  pf <- get("publish_files", envir = globalenv())
+  expect_length(pf$predictions_latest, 1L)
+  expect_match(pf$predictions_latest, "match_features[.]parquet$")
+  # It is a predictions diagnostic, not blog data.
+  expect_length(pf$blog_latest, 0L)
+})
+
+test_that("04b aborts rather than shipping an empty diagnostic", {
+  # A strength subset that matched nothing would still write a valid parquet
+  # and still report SUCCESS -- the exact "looks like it worked" shape this
+  # repo keeps getting bitten by. It must fail loudly instead.
+  skip_if_not_installed("arrow")
+  local_no_reload()
+  d <- withr::local_tempdir()
+  .mf_fixture(d)
+  saveRDS(list(feature_cols = c("nothing_matches_here", "nor_this")),
+          file.path(d, "05_goals_model.rds"))
+  expect_error(.run_04b(d, publish = FALSE), "strength feature columns")
+})


### PR DESCRIPTION
Two commits. The first adds a diagnostic export; the second fixes a mistake in how I wired it.

## Why

`04_match_dataset.rds` is built on the GHA runner and thrown away. Nothing uploads it. So *"what did the model actually see for this fixture?"* cannot be answered without a full local run — and step 02 loads a 5.9GB cache, so that is not a casual thing to do.

Two investigations stalled on this in the same week, both saying so in as many words:

- **#190** — "`04_match_dataset.rds` is a build artifact and is not available outside a pipeline run"
- **#192** — "the published `predictions.parquet` does not [carry actuals], which is why this issue stops at the symptom"

#192's next step is shrinking team aggregates toward a prior when a squad has barely been observed. That needs a shrinkage constant and a prior. Both are numbers to **measure**, not to pick by eye, and neither is measurable today.

## What it does

New opt-in step **4b** writes `match_features.parquet` and registers it for `predictions-latest`: identity columns, the team-strength features, and actual goals, per fixture.

Two choices worth stating:

**The strength subset uses the same regex `07_predict_fixtures.R` uses** for its degraded-features guard — duplicated deliberately, with a comment saying so and saying that if one moves the other must. A diagnostic describing a different column set than the guard inspects would send the next investigation looking somewhere the guard never looks. Confirmed character-for-character identical today.

**It aborts when that regex matches nothing**, rather than writing a valid empty parquet and reporting SUCCESS. Same "looks like it worked" shape as the half-the-bins skills join and the finished-tournament WC simulation. Mutation-tested: removing the guard drops the file to 8 pass / 1 fail.

It is *not* the whole match dataset — ~170 columns × 58k rows is a large asset to publish for a diagnostic, and strength features plus outcomes is what the open questions need.

## The second commit: I reintroduced this morning's outage

Review found it. Step 4b was wired with `run_pipeline_step` (**fatal**), sitting between steps 5 and 6. A failure there sets `pipeline_failed` before steps 6, 7, 9, 10, 10b/c/d, 11–12c **and 13** — every one prints "SKIPPED (previous step failed)" and nothing publishes. A diagnostic column-export could cancel the entire weekly release, and the workflow already enabled it.

The likely trigger was **its own abort-on-empty-regex guard**, fired by a feature rename upstream. That is the 2026-08-13 outage exactly: `build_knockout_lookup()`'s invariant was correct, and it still cost eight days of publishing because a side branch was allowed to be fatal. I fixed that this morning and rebuilt the same shape this evening, at a worse position.

My stated reason for choosing fatal — *"it registers a file for publish"* — does not survive contact with the precedent I set earlier in the same file. Step 12 registers too and is non-fatal, because both register only at the very end after a successful write, so a mid-step failure registers nothing and step 13 has nothing torn to publish. **Position** is what makes fatal expensive here, not publish-safety.

Now uses `run_pred_step_optional`: still FAILED in the summary, still written to `.nonfatal_step_failures` so the workflow raises a GitHub warning annotation, but the release proceeds.

## Verification

- Smoke-tested end to end against a synthetic cache **before** any wiring.
- 9 tests covering exported columns, publish registration, and the empty-subset abort.
- The non-fatal fix verified through the real `run_step` machinery, with 4b failing the way it actually would: `4b=FAILED, step6=SUCCESS, step13=SUCCESS, pipeline_failed=FALSE`, marker recorded.
- **869 pass, 0 fail** across the ten touched test files.
- Workflow `Rscript` payload still parses at 103 lines, checked by `test-workflow-r-payloads.R` — the guard added this morning after I broke exactly this.

## Review

`code-reviewer`, Sonnet. One critical finding — the fatal/non-fatal wiring — fixed in `6080749`. Step-key wiring, the duplicated regex, the test's emulation of the driver's closure wrapping, and the workflow payload all came back clean.

Refs #190, #192.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01533D7gX5RBR78vJbjFL4Yo