### PR TITLE
Narrow the match-features export to what cannot be recomputed

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: panna
 Title: Player Rating System for Football Using RAPM, SPM, and EPV Methods
-Version: 0.3.26
+Version: 0.3.27
 Authors@R:
     person("Pete", "Owen", , "pete.owen1@hotmail.co.uk", role = c("aut", "cre", "cph"))
 Description: Implements player ratings for football (soccer) from 'Opta'

--- a/NEWS.md
+++ b/NEWS.md
@@ -28,12 +28,21 @@ the actual goals, per fixture.
   was wrong by roughly five times — the file is legitimately that size, and
   compression barely moves it (snappy 46.1MB → zstd 43.5MB), so the columns
   are real data rather than bloat.
-* **The derived `*_diff` columns are dropped**, which is the one deliberate
-  departure from mirroring the guard's set. Every one is exactly
-  `home_<base> - away_<base>` and both sides are exported — verified on the
-  published build at 100.0% of rows — so a consumer can recompute any of them.
-  That is worth ~7MB. It is safe only because they are derivable; the test
-  says so, and says that relaxing it to a non-derived column would be a bug.
+* **Derived `*_diff` columns are dropped — but only the ones proved
+  recomputable.** The first attempt dropped all 14 on the strength of checking
+  one (`elo_diff == home_elo - away_elo`, 100% of 58,780 rows) and
+  generalising. Review caught that the generalisation was false: `rest_diff` is
+  `home_days_since_last - away_days_since_last`, and neither operand matches
+  the keep patterns, so dropping it destroyed the only record of rest in the
+  export — silently, which is the failure shape this file exists to help
+  investigate.
+
+  The step now *proves* derivability per column: for each candidate it looks
+  for a surviving `(home_X, away_X)` pair whose difference reproduces it on
+  real rows, and keeps anything that fails to match. No hand-maintained
+  base-name map (`panna_diff` → `sum_panna` is not mechanical), and it cannot
+  rot — a differential added upstream is proved or kept, never silently lost.
+  Against the published build: 13 proved and dropped, `rest_diff` kept.
 * **The step is non-fatal**, and the first version of it was not — a review
   finding. It sits between steps 5 and 6, so a fatal wrapper there sets
   `pipeline_failed` before steps 6, 7, 9, 10, 10b/c/d, 11–12c and 13, and

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,9 +22,18 @@ the actual goals, per fixture.
 * **It aborts if that regex matches nothing**, rather than writing a valid
   empty parquet and reporting SUCCESS — the "looks like it worked" shape this
   pipeline has been bitten by repeatedly.
-* Not the whole match dataset: ~170 columns × 58k rows is a large asset to
-  publish for a diagnostic, and the strength subset plus outcomes is what the
-  open questions actually need.
+* Not the whole match dataset. Measured on the first published build, that is
+  223 columns × 58,780 rows; the export carries 15 identity + 94 strength
+  columns at ~37MB. My pre-build estimate of "~40 strength columns, a few MB"
+  was wrong by roughly five times — the file is legitimately that size, and
+  compression barely moves it (snappy 46.1MB → zstd 43.5MB), so the columns
+  are real data rather than bloat.
+* **The derived `*_diff` columns are dropped**, which is the one deliberate
+  departure from mirroring the guard's set. Every one is exactly
+  `home_<base> - away_<base>` and both sides are exported — verified on the
+  published build at 100.0% of rows — so a consumer can recompute any of them.
+  That is worth ~7MB. It is safe only because they are derivable; the test
+  says so, and says that relaxing it to a non-derived column would be a bug.
 * **The step is non-fatal**, and the first version of it was not — a review
   finding. It sits between steps 5 and 6, so a fatal wrapper there sets
   `pipeline_failed` before steps 6, 7, 9, 10, 10b/c/d, 11–12c and 13, and

--- a/data-raw/match-predictions-opta/04b_export_match_features.R
+++ b/data-raw/match-predictions-opta/04b_export_match_features.R
@@ -46,6 +46,19 @@ strength_cols <- unique(c(
 ))
 strength_cols <- intersect(strength_cols, names(md))
 
+# Drop the derived differentials. Every `*_diff` column is exactly
+# home_<base> - away_<base>, and both sides are already in the export --
+# verified on the first published build: elo_diff == home_elo - away_elo for
+# 100.0% of 58,780 rows. Carrying them costs ~7MB of an asset that is already
+# ~45MB and adds no information a consumer cannot recompute.
+#
+# This is the ONE deliberate departure from mirroring 07_predict_fixtures.R's
+# guard set exactly. It is safe precisely because it is derivable: an
+# investigation that wants a diff can compute it, which is not true of anything
+# else here. Do not extend this to non-derived columns without the same proof.
+derived_cols <- grep("_diff$", strength_cols, value = TRUE)
+strength_cols <- setdiff(strength_cols, derived_cols)
+
 id_cols <- intersect(c("match_id", "match_date", "league", "season",
                        "season_end_year", "split", "match_status",
                        "home_team", "away_team", "home_team_id", "away_team_id",
@@ -53,8 +66,8 @@ id_cols <- intersect(c("match_id", "match_date", "league", "season",
                      names(md))
 
 out <- md[, c(id_cols, strength_cols), with = FALSE]
-message(sprintf("  exporting %d identity + %d strength column(s)",
-                length(id_cols), length(strength_cols)))
+message(sprintf("  exporting %d identity + %d strength column(s) (%d derived *_diff dropped)",
+                length(id_cols), length(strength_cols), length(derived_cols)))
 
 # Assert the export is actually usable for the question it exists to answer:
 # a strength subset that came back empty would still write a valid parquet and
@@ -66,7 +79,9 @@ if (length(strength_cols) == 0L) {
 }
 
 out_path <- file.path(cache_dir, "match_features.parquet")
-arrow::write_parquet(out, out_path)
+# zstd over the snappy default: same data, round-trip identical, a few MB
+# smaller on a file this size.
+arrow::write_parquet(out, out_path, compression = "zstd")
 message(sprintf("  Written: %s (%d rows, %.1f MB)",
                 basename(out_path), nrow(out), file.size(out_path) / 1024^2))
 

--- a/data-raw/match-predictions-opta/04b_export_match_features.R
+++ b/data-raw/match-predictions-opta/04b_export_match_features.R
@@ -46,17 +46,42 @@ strength_cols <- unique(c(
 ))
 strength_cols <- intersect(strength_cols, names(md))
 
-# Drop the derived differentials. Every `*_diff` column is exactly
-# home_<base> - away_<base>, and both sides are already in the export --
-# verified on the first published build: elo_diff == home_elo - away_elo for
-# 100.0% of 58,780 rows. Carrying them costs ~7MB of an asset that is already
-# ~45MB and adds no information a consumer cannot recompute.
+# Drop the derived differentials -- but only the ones we can PROVE are
+# recomputable from columns that survive. The first version of this dropped
+# everything matching `_diff$` on the strength of checking one column
+# (elo_diff == home_elo - away_elo, 100% of 58,780 rows) and generalising.
+# That generalisation was false: `rest_diff` is
+# home_days_since_last - away_days_since_last, and neither operand matches the
+# keep patterns above, so dropping it destroyed the only record of rest in the
+# export -- silently, which is the failure shape this file exists to help
+# investigate.
 #
-# This is the ONE deliberate departure from mirroring 07_predict_fixtures.R's
-# guard set exactly. It is safe precisely because it is derivable: an
-# investigation that wants a diff can compute it, which is not true of anything
-# else here. Do not extend this to non-derived columns without the same proof.
-derived_cols <- grep("_diff$", strength_cols, value = TRUE)
+# So prove it per column instead of asserting it. For each candidate, look for
+# a surviving (home_X, away_X) pair whose difference reproduces it on real
+# rows. Anything that fails to match is KEPT. This needs no hand-maintained
+# base-name map (panna_diff -> sum_panna is not mechanical) and it cannot rot:
+# a new differential added upstream is proved or kept, never silently lost.
+.diff_candidates <- grep("_diff$", strength_cols, value = TRUE)
+.bases <- unique(sub("^home_", "", grep("^home_", strength_cols, value = TRUE)))
+.probe <- utils::head(which(stats::complete.cases(md[, strength_cols, with = FALSE])), 500L)
+derived_cols <- character(0)
+for (dcol in .diff_candidates) {
+  if (!length(.probe)) break
+  dv <- as.numeric(md[[dcol]][.probe])
+  for (b in .bases) {
+    h <- paste0("home_", b); a <- paste0("away_", b)
+    if (!all(c(h, a) %in% strength_cols)) next
+    if (isTRUE(all.equal(dv, as.numeric(md[[h]][.probe]) - as.numeric(md[[a]][.probe]),
+                         tolerance = 1e-8))) {
+      derived_cols <- c(derived_cols, dcol); break
+    }
+  }
+}
+kept_diffs <- setdiff(.diff_candidates, derived_cols)
+if (length(kept_diffs) > 0) {
+  message(sprintf("  keeping %d differential(s) whose operands are NOT exported: %s",
+                  length(kept_diffs), paste(kept_diffs, collapse = ", ")))
+}
 strength_cols <- setdiff(strength_cols, derived_cols)
 
 id_cols <- intersect(c("match_id", "match_date", "league", "season",

--- a/tests/testthat/test-match-features-export.R
+++ b/tests/testthat/test-match-features-export.R
@@ -68,8 +68,16 @@ test_that("04b exports the strength features and the actuals, and nothing else",
   expect_equal(nrow(out), 40L)
   # Strength features: the whole point of the export.
   expect_true(all(c("home_sum_panna", "away_sum_panna", "home_elo", "away_elo",
-                    "elo_diff", "panna_diff", "home_avg_psr", "away_avg_psr")
-                  %in% names(out)))
+                    "home_avg_psr", "away_avg_psr") %in% names(out)))
+  # Derived differentials are deliberately dropped: every *_diff is exactly
+  # home_<base> - away_<base>, both sides are here, and a consumer can
+  # recompute it. Verified on the first published build (elo_diff ==
+  # home_elo - away_elo for 100.0% of 58,780 rows). This is the only
+  # departure from mirroring 07_predict_fixtures.R's guard set, and it is
+  # safe only because it is derivable -- if this assertion is ever relaxed to
+  # cover a NON-derived column, that is a bug, not a tidy-up.
+  expect_false(any(c("elo_diff", "panna_diff") %in% names(out)))
+  expect_true(all(c("home_elo", "away_elo") %in% names(out)))
   # Actuals: without these the export cannot be calibrated against outcomes,
   # which is most of why panna#192 wanted it.
   expect_true(all(c("home_goals", "away_goals") %in% names(out)))

--- a/tests/testthat/test-match-features-export.R
+++ b/tests/testthat/test-match-features-export.R
@@ -24,12 +24,16 @@ local_no_reload <- function(env = parent.frame()) {
     home_elo = 1500, away_elo = 1400, elo_diff = 100, panna_diff = -1,
     home_avg_psr = 0.5, away_avg_psr = 0.4,
     diff_form = 0.1, some_other_col = 9,
+    # rest_diff-shaped: matches _diff$, but its operands are named so
+    # that no keep-pattern exports them. Dropping it would be lossy.
+    rest_diff = 3, home_days_since_last = 7, away_days_since_last = 4,
     stringsAsFactors = FALSE)
   saveRDS(md, file.path(dir, "04_match_dataset.rds"))
   saveRDS(list(feature_cols = c("home_sum_panna", "away_sum_panna", "home_elo",
                                 "away_elo", "elo_diff", "panna_diff",
                                 "home_avg_psr", "away_avg_psr", "diff_form",
-                                "some_other_col")),
+                                "some_other_col", "rest_diff",
+                                "home_days_since_last", "away_days_since_last")),
           file.path(dir, "05_goals_model.rds"))
   dir
 }
@@ -86,6 +90,27 @@ test_that("04b exports the strength features and the actuals, and nothing else",
   # A feature that is neither strength nor identity must not ride along --
   # otherwise this quietly becomes a full match-dataset dump.
   expect_false("some_other_col" %in% names(out))
+})
+
+test_that("a differential whose operands are NOT exported is kept, not dropped", {
+  # The bug this pins: dropping every `_diff$` column on the strength of
+  # checking one of them. rest_diff is home_days_since_last -
+  # away_days_since_last, and neither operand matches the keep patterns, so
+  # dropping it destroys the only record of rest in the export -- silently.
+  # Derivability has to be proved per column, not assumed from a sibling.
+  skip_if_not_installed("arrow")
+  local_no_reload()
+  d <- .mf_fixture(withr::local_tempdir())
+  on.exit(suppressWarnings(rm("publish_files", envir = globalenv())), add = TRUE)
+
+  .run_04b(d)
+  out <- arrow::read_parquet(file.path(d, "match_features.parquet"))
+
+  # Kept: not recomputable from anything that survives.
+  expect_true("rest_diff" %in% names(out))
+  # And still dropped: the ones that genuinely are recomputable.
+  expect_false("panna_diff" %in% names(out))
+  expect_true(all(c("home_sum_panna", "away_sum_panna") %in% names(out)))
 })
 
 test_that("04b registers exactly one file for publish, and only when asked", {


### PR DESCRIPTION
Follow-up to #197. The first published `match_features.parquet` came in at **45.5 MB**, not the "few MB" I claimed there — 223 columns in the match dataset rather than ~170, and 108 strength columns rather than ~40. The reviewer on #197 flagged they couldn't verify that estimate without a live cache. They were right to; it was wrong by about five times.

## Having measured instead of guessed, the file is legitimately that size

Compression barely moves it — snappy 46.1 MB, zstd 43.5 MB — so those are 108 columns of real per-fixture numbers, not bloat. My instinct that it needed narrowing was mostly wrong.

The one defensible cut is the derived differentials: a column a consumer can recompute is pure redundancy in a diagnostic. With zstd that lands at ~37 MB, round-trip identical.

## The interesting part: my first attempt at that cut was wrong

I verified `elo_diff == home_elo - away_elo` for 100.0% of 58,780 rows, then dropped **all 14** `*_diff` columns and wrote a comment asserting as fact that every one was recomputable.

Review caught that it wasn't. `rest_diff` is `home_days_since_last - away_days_since_last`, and neither operand matches any keep pattern — so both were already absent from the export. Dropping `rest_diff` destroyed the only record of rest in the file, silently, while the comment guaranteed that couldn't happen. In a file whose entire purpose is helping people investigate silent data problems, that's worse than merely wrong.

## So it proves derivability now, per column

For each `_diff$` candidate, it looks for a surviving `(home_X, away_X)` pair whose difference reproduces it on up to 500 complete rows. Anything that fails to match is **kept**, and named in the log.

Empirical rather than a base-name map, for two reasons: `panna_diff → sum_panna` isn't mechanical, so a map would have to be hand-maintained beside the one in `knockout_model.R` and could drift from it — and a proof can't rot. A differential added upstream gets proved or kept, never silently lost.

Against the real published build:

```
PROVED derivable (dropped): 13
   elo_diff, panna_diff, offense_diff, defense_diff, spm_diff, epr_diff,
   epr_off_diff, epr_def_diff, psr_diff, osr_diff, dsr_diff,
   sk_att_diff, sk_def_diff

KEPT (operands not exported): rest_diff
```

## Verification

- **Mutation-tested**: restoring the blanket drop fails the new test (13 pass / 1 fail); restored, 14 pass.
- The fixture now carries a `rest_diff`-shaped column — matches `_diff$`, operands deliberately unexportable — which the previous test set had no case for, which is precisely why it caught nothing.
- **874 pass, 0 fail** across the touched files.
- The `zstd` switch is a one-off in this repo (everything else uses the snappy default). Reviewer confirmed CRAN's arrow binaries bundle zstd and readers auto-detect the codec from file metadata, so there's no "diagnostic nobody can open" risk.

## Review

`code-reviewer`, Sonnet. One critical finding — the false derivability claim — fixed in `8ef6825`. Its second finding, that the test couldn't catch that class of bug, is fixed by the new fixture case.

Refs #190, #192.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01533D7gX5RBR78vJbjFL4Yo