### PR TITLE
Domestic Tiento: a team-strength rating for every club, not just the World Cup 48

### DIFF
--- a/.github/workflows/predictions-pipeline.yml
+++ b/.github/workflows/predictions-pipeline.yml
@@ -304,6 +304,12 @@ jobs:
               # snapshots to wc2026-strength-history so tournament rating drift
               # is tracked going forward (no replay needed next time).
               step_12c_snapshot_wc_strength  = TRUE,
+              # Tiento for every domestic-league + cup-only club (panna#193),
+              # not just the WC2026 48 -- the blog's Team Ratings page reads
+              # team_strength.parquet for the headline rating everywhere.
+              # Non-fatal like 11/12/12b/12c, for the same reason (a side
+              # export failing must never hold back predictions-latest).
+              step_12d_export_domestic_team_strength = TRUE,
               # Single gated publish of predictions-latest + blog-latest
               # (ECOSYSTEM-FIX-PLAN.md PA5/H-TORN) -- steps 09/10/10b/10c/10d/12
               # above now write LOCAL outputs only; this is the one place

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: panna
 Title: Player Rating System for Football Using RAPM, SPM, and EPV Methods
-Version: 0.3.29
+Version: 0.3.30
 Authors@R:
     person("Pete", "Owen", , "pete.owen1@hotmail.co.uk", role = c("aut", "cre", "cph"))
 Description: Implements player ratings for football (soccer) from 'Opta'

--- a/NEWS.md
+++ b/NEWS.md
@@ -24,7 +24,8 @@ deliberately surfaces that as NA rather than falling back to `ELO_INITIAL =
 1500`. This step seeds such a team at the mean final Elo of the teams
 relegated from that league the previous season -- measured near-unbiased
 (mean error +15, MAE 69, sd 89 across 57 clean league-seasons) versus the
-league mean (~80 MAE) or 1500 (~112 MAE), so no correction term. Falls back to
+league mean (179 MAE) or ELO_INITIAL=1500 (97 MAE), so no correction term.
+Falls back to
 the league mean (and says so in the log) when no relegated cohort is
 identifiable -- a league's first tracked season, or a cup-only team (a cup has
 no relegation concept). `elo_seeded` marks every seeded team; `seed_method`

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,37 @@
 # panna 0.3.28 (dev)
 
+## Tiento for every domestic + cup club, not just the World Cup 48 (panna#193)
+
+New step `12d_export_domestic_team_strength.R` publishes `team_strength.parquet`
+(one row per team: `panna, offense, defense, epr, psr, elo, tiento, rank_tiento,
+squad_n, n_rated, elo_seeded, seed_method, is_domestic_league, build_id`) for
+every club in the current fixture window -- domestic-league clubs and cup-only
+clubs from leagues panna doesn't scrape (e.g. Champions League opponents,
+~253 teams at spec time). Squad aggregation mirrors `12_export_wc2026_blog.R`
+section 5 exactly (`build_team_expected_minutes(international_only = FALSE)`,
+same minutes-weighted formula, same rating sources), and Tiento reuses the
+existing weights (`panna .40 / epr .20 / elo .30 / psr .10`) unmodified,
+z-scored across the GLOBAL pool per `DOMESTIC-TIENTO-2026-08-21.md`. A
+dual-labelled team (domestic league + a continental cup this season, ~19 of
+them) is pinned to its domestic league.
+
+Elo is the one genuinely new piece: a team freshly promoted from a division
+panna doesn't scrape (currently Le Mans FC from Ligue 2, SV 07 Elversberg from
+2. Bundesliga -- confirmed against the live `predictions-latest` release,
+which shows exactly these two and no others with NA Elo in the current
+fixture window) has no tracked history at all, and `03_team_rolling_features.R`
+deliberately surfaces that as NA rather than falling back to `ELO_INITIAL =
+1500`. This step seeds such a team at the mean final Elo of the teams
+relegated from that league the previous season -- measured near-unbiased
+(mean error +15, MAE 69, sd 89 across 57 clean league-seasons) versus the
+league mean (~80 MAE) or 1500 (~112 MAE), so no correction term. Falls back to
+the league mean (and says so in the log) when no relegated cohort is
+identifiable -- a league's first tracked season, or a cup-only team (a cup has
+no relegation concept). `elo_seeded` marks every seeded team; `seed_method`
+records which rule fired. Non-fatal in the pipeline (`run_pred_step_optional`,
+step 12d) -- a failure here must never hold back predictions-latest or
+blog-latest, same reasoning as step 12.
+
 ## A missing events table no longer discards an entire season's matches (panna#166)
 
 `01_build_fixture_results.R` loaded `events` before `fixtures` in its per-

--- a/data-raw/match-predictions-opta/12d_export_domestic_team_strength.R
+++ b/data-raw/match-predictions-opta/12d_export_domestic_team_strength.R
@@ -161,9 +161,14 @@ message("\n=== Exporting domestic + cup team strength (Tiento, all clubs) ===\n"
 #' Measured rule (panna#193 spec, 57 clean league-seasons ENG/ESP/ITA/FRA/GER):
 #' seeding a promoted team at the mean final Elo of the PREVIOUS season's
 #' relegated cohort is essentially unbiased (mean error +15, MAE 69, sd 89) --
-#' clearly better than the league mean (~80 MAE) or ELO_INITIAL=1500 (~112
+#' clearly better than the league mean (179 MAE) or ELO_INITIAL=1500 (97
 #' MAE). No correction term: the bias is small enough relative to the spread
 #' to not be worth adding one.
+#'
+#' Re-derive with data-raw/debug/keep/_elo_seed_rule_measurement.R rather than
+#' trusting these figures -- it names the one trap that matters (738 of 7,135
+#' club-seasons start at exactly ELO_INITIAL, and leaving them in inflates the
+#' apparent bias from +15 to +50).
 #'
 #' Falls back to the league mean (excluding NA-elo teams) when no relegated
 #' cohort is identifiable -- no prior season tracked at all (a league's first
@@ -418,9 +423,17 @@ agg_rows <- vector("list", length(teams))
 for (i in seq_along(teams)) {
   tm <- teams[i]
   lu_team <- if (tm %in% lu_known_teams) lu_all[.(tm)] else lu_all[0L]
+  # lookback_days = 1095L, NOT the 730L library default. announced_squads.R
+  # passes 1095 at both of its build_team_expected_minutes() call sites, so
+  # taking the default here would have quietly made domestic Tiento mean
+  # something different from WC Tiento -- which is the one thing this step is
+  # not allowed to do. Caught in review; the header claimed parity the code did
+  # not have. Practical effect is on which fringe players clear the evidence
+  # bar, which matters most for exactly the thin-history clubs this step
+  # handles specially.
   em <- panna::build_team_expected_minutes(
     team = tm, lineups = lu_team, as_of = as_of_domestic,
-    international_only = FALSE
+    international_only = FALSE, lookback_days = 1095L
   )
   if (is.null(em) || nrow(em) == 0L || !"player_id" %in% names(em)) {
     agg_rows[[i]] <- data.table::data.table(

--- a/data-raw/match-predictions-opta/12d_export_domestic_team_strength.R
+++ b/data-raw/match-predictions-opta/12d_export_domestic_team_strength.R
@@ -1,0 +1,498 @@
+# 12d_export_domestic_team_strength.R
+# Export Tiento (the composite team rating) for EVERY club panna tracks --
+# not just the World Cup 48. Domestic sibling of 12_export_wc2026_blog.R
+# section 5 (panna#193): the blog's Team Ratings page currently shows the sum
+# of the top-20 players' panna, not Tiento, because Tiento's inputs (squad EM,
+# Elo as a team property) had never been pointed at club football. This step
+# is that wiring.
+#
+# Output:
+#   team_strength.parquet -- one row per team, ALL teams appearing in the
+#   current fixture window (domestic-league clubs AND cup-only clubs from
+#   leagues panna does not scrape, e.g. Champions League opponents), columns:
+#     team, league, panna, offense, defense, epr, psr, elo, tiento, rank_tiento,
+#     squad_n, n_rated, elo_seeded, is_domestic_league, build_id
+#
+# Squad aggregation mirrors 12_export_wc2026_blog.R section 5 EXACTLY (same
+# minutes-weighted formula, same rating sources) so a domestic Tiento means the
+# same thing as a WC Tiento. The one genuinely new piece is Elo: WC pulls it
+# from the match dataset because every WC team already has qualifying-cycle
+# history. Domestic football has real promotion/relegation, so some teams have
+# NO tracked history at all (promoted from a division panna doesn't scrape) --
+# see the Elo-seeding section below.
+#
+# Inputs:
+#   01_fixture_results.rds        -- league/season/team roster + full match
+#                                     history (for Elo re-derivation)
+#   opta_lineups.parquet          -- squad EM source (ALL competitions; this
+#                                     is domestic, so international_only=FALSE)
+#   career_panna.parquet, opta_epr_weekly.parquet, cache-skills/06 or
+#   cache-opta/07 seasonal ratings -- same rating sources section 5 reads
+
+# 1. Configuration ----
+
+if (!exists("cache_dir")) cache_dir <- file.path("data-raw", "cache-predictions-opta")
+
+suppressPackageStartupMessages({ library(data.table); library(arrow) })
+devtools::load_all()   # PANNA_LEAGUE_GROUPS, ELO_MATCH_TYPE_K, etc.
+
+# Config-override pattern (see panna/CLAUDE.md "Config override pattern"):
+# tests set these before sourcing to shrink the scope to a couple of fake
+# leagues instead of the full 14 domestic + 4 continental codes.
+if (!exists("domestic_codes")) {
+  domestic_codes <- c(PANNA_LEAGUE_GROUPS$domestic, PANNA_LEAGUE_GROUPS$calendar)
+}
+if (!exists("cup_codes")) cup_codes <- PANNA_LEAGUE_GROUPS$continental
+if (!exists("as_of_domestic")) as_of_domestic <- Sys.Date()
+# Below this, a squad is not a small roster -- it is a broken team_name join
+# (announced_name mismatch, opta_lineups drift). 26-man cap makes even a
+# genuinely thin squad clear the bar comfortably.
+if (!exists("MIN_PLAUSIBLE_SQUAD_N")) MIN_PLAUSIBLE_SQUAD_N <- 5L
+
+TIENTO_WEIGHTS <- c(panna = 0.40, epr = 0.20, elo = 0.30, psr = 0.10)  # DO NOT re-fit; 12_export_wc2026_blog.R:359 is the one derivation
+
+message("\n=== Exporting domestic + cup team strength (Tiento, all clubs) ===\n")
+
+# 2. Helper functions (defined here so tests can source() this file and call
+#    them directly on hand-built fixtures, same idiom the WC exporter uses for
+#    team_metric()) ----
+
+#' Classify every team's (league, is_domestic) for the CURRENT season
+#'
+#' A club plays in exactly one domestic league but can ALSO appear this same
+#' season under a continental cup code (UCL/UEL/UECL/CAFCL) -- 19 such teams
+#' at spec-writing time. Domestic always wins (Pete's call, DOMESTIC-TIENTO
+#' plan "pin the 19 dual-labelled teams to their domestic league"): a team's
+#' cup run does not change what league it is scored against.
+#'
+#' "Current season" is determined PER LEAGUE (max season_end_year present for
+#' that league in fixture_results) rather than one global season, because
+#' domestic leagues use different label formats (European "2025-2026" vs
+#' calendar-year MLS/ARG/BRA) that can sit at different season_end_years at
+#' the same wall-clock date.
+#'
+#' @param fixture_results data.table (or data.frame) with league, season_end_year,
+#'   home_team, away_team, match_status.
+#' @param domestic_codes,cup_codes Character vectors of league codes.
+#' @return data.table(team, league, is_domestic_league, cur_sey)
+.classify_team_leagues <- function(fixture_results, domestic_codes, cup_codes) {
+  fr <- data.table::as.data.table(fixture_results)
+  scope <- c(domestic_codes, cup_codes)
+  fr <- fr[league %in% scope]
+  if (nrow(fr) == 0L) {
+    return(data.table::data.table(team = character(0), league = character(0),
+                                   is_domestic_league = logical(0), cur_sey = numeric(0)))
+  }
+  cur_sey_by_league <- fr[, .(cur_sey = max(season_end_year, na.rm = TRUE)), by = league]
+  fr <- merge(fr, cur_sey_by_league, by = "league")
+  fr <- fr[season_end_year == cur_sey]
+
+  rows <- data.table::rbindlist(list(
+    fr[, .(team = home_team, league, cur_sey)],
+    fr[, .(team = away_team, league, cur_sey)]
+  ))
+  rows <- rows[!is.na(team) & nzchar(team)]
+  tally <- rows[, .N, by = .(team, league, cur_sey)]
+
+  is_dom_league <- tally$league %in% domestic_codes
+  dom <- tally[is_dom_league]
+  cup <- tally[!is_dom_league]
+
+  # Pick the most-frequent league per team within each pool (a genuine data
+  # anomaly -- mid-season rename, dual domestic entries -- should not crash
+  # the export; deterministic tie-break by row count then league code).
+  .pick_one <- function(dt) {
+    if (nrow(dt) == 0L) return(dt)
+    data.table::setorder(dt, team, -N, league)
+    dt[, .SD[1L], by = team]
+  }
+  dom1 <- .pick_one(dom)
+  cup1 <- .pick_one(cup)
+
+  multi_dom <- dom[, .N, by = team][N > 1L]
+  if (nrow(multi_dom) > 0L) {
+    message(sprintf(
+      "  NOTE: %d team(s) matched >1 domestic league this season (kept the most-frequent): %s",
+      nrow(multi_dom), paste(multi_dom$team, collapse = ", ")))
+  }
+
+  # Domestic wins over cup for any team present in both pools.
+  dom_teams <- dom1$team
+  cup_only <- cup1[!team %in% dom_teams]
+
+  out <- data.table::rbindlist(list(
+    dom1[, .(team, league, is_domestic_league = TRUE, cur_sey)],
+    cup_only[, .(team, league, is_domestic_league = FALSE, cur_sey)]
+  ))
+  out
+}
+
+#' Teams relegated OUT of `league` between `prev_sey` and `cur_sey`
+#'
+#' "Relegated" here is inferred, not flagged in the data: teams that played a
+#' full season in `league` at `prev_sey` and do not appear in `league` at
+#' `cur_sey`. Within the set of leagues panna tracks, dropping out of a
+#' tracked top flight overwhelmingly means relegation to an untracked division
+#' (Ligue 2, 2. Bundesliga, ...) rather than a folded club -- the one
+#' operationalisation of Pete's rule that needs no relegation-table data panna
+#' doesn't have.
+#'
+#' @return Character vector of team names (possibly empty).
+.relegated_cohort <- function(fixture_results, league_code, cur_sey) {
+  fr <- data.table::as.data.table(fixture_results)
+  lg <- fr[league == league_code]
+  prior_seys <- lg$season_end_year[lg$season_end_year < cur_sey]
+  if (length(prior_seys) == 0L) return(character(0))
+  prev_sey <- max(prior_seys, na.rm = TRUE)
+
+  prev_played <- lg[season_end_year == prev_sey & match_status == "Played"]
+  teams_prev <- unique(c(prev_played$home_team, prev_played$away_team))
+  teams_prev <- teams_prev[!is.na(teams_prev) & nzchar(teams_prev)]
+
+  curr <- lg[season_end_year == cur_sey]
+  teams_curr <- unique(c(curr$home_team, curr$away_team))
+  teams_curr <- teams_curr[!is.na(teams_curr) & nzchar(teams_curr)]
+
+  setdiff(teams_prev, teams_curr)
+}
+
+#' Seed Elo for every team with no tracked history
+#'
+#' Measured rule (panna#193 spec, 57 clean league-seasons ENG/ESP/ITA/FRA/GER):
+#' seeding a promoted team at the mean final Elo of the PREVIOUS season's
+#' relegated cohort is essentially unbiased (mean error +15, MAE 69, sd 89) --
+#' clearly better than the league mean (~80 MAE) or ELO_INITIAL=1500 (~112
+#' MAE). No correction term: the bias is small enough relative to the spread
+#' to not be worth adding one.
+#'
+#' Falls back to the league mean (excluding NA-elo teams) when no relegated
+#' cohort is identifiable -- no prior season tracked at all (a league's first
+#' tracked season), or the team is cup-only (a cup has no relegation concept
+#' to infer from). Every fallback is logged, per the "say so in the log, don't
+#' silently use 1500" instruction.
+#'
+#' @param final_elos Named numeric vector, team -> final Elo (NA/absent = no
+#'   tracked history at all).
+#' @param team_league data.table from `.classify_team_leagues()`.
+#' @param fixture_results Full fixture history (for `.relegated_cohort()`).
+#' @return data.table(team, elo, elo_seeded, seed_method, seed_n)
+.seed_missing_elo <- function(final_elos, team_league, fixture_results) {
+  elo_of <- function(team) {
+    v <- unname(final_elos[team])
+    if (length(v) == 0L) NA_real_ else v
+  }
+  out <- data.table::copy(team_league)
+  out[, elo := vapply(team, elo_of, numeric(1))]
+  out[, elo_seeded := is.na(elo)]
+  out[, seed_method := ifelse(elo_seeded, NA_character_, "earned")]
+  out[, seed_n := NA_integer_]
+
+  needs_seed <- out[elo_seeded == TRUE]
+  if (nrow(needs_seed) == 0L) return(out[, .(team, elo, elo_seeded, seed_method, seed_n)])
+
+  for (i in seq_len(nrow(needs_seed))) {
+    tm  <- needs_seed$team[i]
+    lg  <- needs_seed$league[i]
+    sey <- needs_seed$cur_sey[i]
+    is_dom <- isTRUE(needs_seed$is_domestic_league[i])
+
+    seed <- NA_real_; method <- NA_character_; n_used <- 0L
+
+    if (is_dom) {
+      relegated <- .relegated_cohort(fixture_results, lg, sey)
+      relegated <- setdiff(relegated, tm)
+      releg_elos <- vapply(relegated, elo_of, numeric(1))
+      releg_elos <- releg_elos[!is.na(releg_elos)]
+      if (length(releg_elos) > 0L) {
+        seed <- mean(releg_elos); method <- "relegated_cohort"; n_used <- length(releg_elos)
+      }
+    }
+
+    if (is.na(seed)) {
+      # League-mean fallback: this season's OTHER teams in the same league
+      # (or cup) with earned (non-seeded, non-NA) Elo.
+      peers <- out[league == lg & team != tm & !elo_seeded & !is.na(elo)]
+      if (nrow(peers) > 0L) {
+        seed <- mean(peers$elo); n_used <- nrow(peers)
+        method <- if (is_dom) "league_mean_fallback" else "league_mean_fallback_cup"
+        message(sprintf(
+          "  Elo seed [%s / %s]: no identifiable relegated cohort -- falling back to league mean (n=%d peers, mean=%.0f)",
+          tm, lg, n_used, seed))
+      }
+    }
+
+    if (!is.na(seed)) {
+      out[team == tm, `:=`(elo = seed, seed_method = method, seed_n = n_used)]
+    } else {
+      message(sprintf(
+        "  WARNING: Elo seed [%s / %s]: no relegated cohort AND no league-mean peers -- elo stays NA",
+        tm, lg))
+    }
+  }
+
+  out[, .(team, elo, elo_seeded, seed_method, seed_n)]
+}
+
+#' Weighted z-blend Tiento, z-scored across the GLOBAL pool (all teams)
+#'
+#' Same math as 12_export_wc2026_blog.R:360-366, factored out so it can be
+#' unit-tested against hand-computed z-scores. DOMESTIC-TIENTO-2026-08-21.md
+#' "The one real design decision" -- global pool, not per-league -- so a
+#' Championship side reads low by construction (honest; goes in the blog
+#' tooltip, not fixed here).
+.compute_tiento <- function(strength_dt, weights = TIENTO_WEIGHTS) {
+  dt <- data.table::copy(strength_dt)
+  .z_score <- function(v) {
+    m <- mean(v, na.rm = TRUE); s <- stats::sd(v, na.rm = TRUE)
+    if (is.na(s) || s == 0) rep(0, length(v)) else ifelse(is.na(v), 0, (v - m) / s)
+  }
+  dt[, tiento := rowSums(sapply(names(weights),
+                    function(col) weights[[col]] * .z_score(dt[[col]])))]
+  dt[, rank_tiento := data.table::frank(-tiento, ties.method = "min")]
+  dt
+}
+
+#' Assert-before-publish guards. Refuses rather than ships something
+#' half-right (panna#193 instruction). Each check here is mutation-tested in
+#' tests/testthat/test-domestic-team-strength.R.
+.validate_domestic_strength <- function(strength_dt, min_squad_n = MIN_PLAUSIBLE_SQUAD_N) {
+  dt <- strength_dt
+
+  no_league <- dt$team[is.na(dt$league) | !nzchar(dt$league)]
+  if (length(no_league) > 0L) {
+    stop(sprintf("domestic_team_strength: %d team(s) have no league: %s",
+                 length(no_league), paste(no_league, collapse = ", ")), call. = FALSE)
+  }
+  no_tiento <- dt$team[is.na(dt$tiento)]
+  if (length(no_tiento) > 0L) {
+    stop(sprintf("domestic_team_strength: %d team(s) have NA tiento: %s",
+                 length(no_tiento), paste(no_tiento, collapse = ", ")), call. = FALSE)
+  }
+  elo_na <- dt$team[is.na(dt$elo)]
+  if (length(elo_na) > 0L) {
+    stop(sprintf(paste("domestic_team_strength: elo missing for %d team(s) even after",
+                       "seeding: %s -- no relegated cohort AND no league-mean peers."),
+                 length(elo_na), paste(elo_na, collapse = ", ")), call. = FALSE)
+  }
+  small_squads <- dt[squad_n < min_squad_n]
+  if (nrow(small_squads) > 0L) {
+    stop(sprintf(paste("domestic_team_strength: %d team(s) have implausibly small squads",
+                       "(<%d players -- broken team_name join, not a small squad): %s"),
+                 nrow(small_squads), min_squad_n,
+                 paste(sprintf("%s(%d)", small_squads$team, small_squads$squad_n), collapse = ", ")),
+         call. = FALSE)
+  }
+  for (mt in c("panna", "epr", "psr")) {
+    nz <- mean(dt[[mt]] != 0, na.rm = TRUE)
+    if (is.nan(nz) || nz < 0.5) {
+      stop(sprintf(paste("domestic_team_strength: %s is zero (or all-NA) for >=50%% of teams --",
+                         "likely a squad rating-join failure. Refusing to publish."), mt),
+           call. = FALSE)
+    }
+  }
+
+  message(sprintf("  Guard: squad_n range %d-%d across %d teams",
+                  min(dt$squad_n), max(dt$squad_n), nrow(dt)))
+  message(sprintf("  Guard: tiento mean=%.3f sd=%.3f", mean(dt$tiento), stats::sd(dt$tiento)))
+  top5 <- utils::head(dt[order(-tiento)], 5L)
+  bot5 <- utils::head(dt[order(tiento)], 5L)
+  message("  Top 5 by tiento: ", paste(sprintf("%s (%.2f)", top5$team, top5$tiento), collapse = ", "))
+  message("  Bottom 5 by tiento: ", paste(sprintf("%s (%.2f)", bot5$team, bot5$tiento), collapse = ", "))
+  invisible(TRUE)
+}
+
+# 3. Driver ----
+# Guarded so tests can source() this file to get the helper functions above
+# (for hand-built-fixture unit tests, e.g. `.seed_missing_elo()` on a tiny
+# synthetic final_elos vector) WITHOUT needing a full opta_lineups.parquet +
+# career_panna.parquet + seasonal-ratings fixture set on disk. Same idiom as
+# announced_squads.R's `WC2026_ANNOUNCED_SQUADS_SOURCE_ONLY` guard. Production
+# (run_predictions_opta.R's step 12d) never sets this flag, so the driver
+# always runs there -- this is purely a testability seam.
+if (!exists("DOMESTIC_TEAM_STRENGTH_SOURCE_ONLY") ||
+    !isTRUE(DOMESTIC_TEAM_STRENGTH_SOURCE_ONLY)) {
+
+fr_path <- file.path(cache_dir, "01_fixture_results.rds")
+if (!file.exists(fr_path)) {
+  stop("01_fixture_results.rds not found in ", cache_dir, " -- run step 01 first.", call. = FALSE)
+}
+fixture_results <- data.table::as.data.table(readRDS(fr_path))
+
+team_league <- .classify_team_leagues(fixture_results, domestic_codes, cup_codes)
+if (nrow(team_league) == 0L) {
+  stop("domestic_team_strength: 0 teams matched domestic_codes/cup_codes in ",
+       "01_fixture_results.rds -- check the league-code scope.", call. = FALSE)
+}
+message(sprintf("  Team scope: %d teams (%d domestic-league, %d cup-only)",
+                nrow(team_league), sum(team_league$is_domestic_league),
+                sum(!team_league$is_domestic_league)))
+
+# 3b. Elo: re-derive final_elos ----
+# compute_match_elos()'s `final_elos` (post-iteration team state) is exactly
+# what step 3 (03_team_rolling_features.R) computes internally to look up
+# upcoming-fixture Elo, but it is never persisted -- step 3 keeps only the
+# per-match PRE-match features it derives from it. A relegated team's frozen
+# final Elo needs the vector itself, so this duplicates step 3's call. K=20 /
+# home_advantage=88 / initial_elo=1500 are step 3's own local constants
+# (03_team_rolling_features.R:17-19, "ELO_K"/"ELO_HOME_ADV"/"ELO_INITIAL") --
+# not package constants, so this MUST be kept in sync by hand if those change.
+# k_table/cross_conf_mult/conf_priors ARE package constants (R/elo_calibration.R)
+# and stay in sync automatically.
+played <- fixture_results[match_status == "Played"]
+played <- played[order(match_date)]
+elo_result <- compute_match_elos(
+  played,
+  k = 20, home_advantage = 88, initial_elo = 1500,
+  k_table = ELO_MATCH_TYPE_K,
+  cross_conf_mult = ELO_CROSS_CONF_MULT,
+  conf_priors = ELO_CONFEDERATION_PRIORS,
+  use_venue_factor = TRUE
+)
+final_elos <- elo_result$final_elos
+
+elo_dt <- .seed_missing_elo(final_elos, team_league, fixture_results)
+n_seeded <- sum(elo_dt$elo_seeded)
+if (n_seeded > 0L) {
+  message(sprintf("  Elo: %d/%d teams seeded (no tracked history): %s",
+                  n_seeded, nrow(elo_dt),
+                  paste(elo_dt$team[elo_dt$elo_seeded], collapse = ", ")))
+}
+
+team_league <- merge(team_league, elo_dt, by = "team")
+
+# 4. Squad ratings + team strength (mirrors 12_export_wc2026_blog.R section 5
+#    exactly, minus the WC-only announced-squad step -- built directly from
+#    opta_lineups via build_team_expected_minutes(international_only=FALSE),
+#    per the panna#193 brief) ----
+
+lineups_path <- file.path(opta_data_dir(), "opta_lineups.parquet")
+if (!file.exists(lineups_path)) {
+  stop("opta_lineups.parquet not found at ", lineups_path, call. = FALSE)
+}
+lu_all <- as.data.table(read_parquet(
+  lineups_path,
+  col_select = c("team_name", "match_id", "match_date", "player_id",
+                "player_name", "position", "is_starter", "minutes_played",
+                "competition")))
+data.table::setkey(lu_all, team_name)
+lu_known_teams <- unique(lu_all$team_name)
+
+cp_path <- file.path(opta_data_dir(), "career_panna.parquet")
+if (!file.exists(cp_path)) {
+  stop("career_panna.parquet not found at ", cp_path, " -- domestic Tiento needs ",
+       "the same career-trait panna the blog publishes elsewhere.", call. = FALSE)
+}
+sq_panna <- as.data.table(read_parquet(cp_path))[
+  , .(player_id, panna, offense = panna_offense, defense = panna_defense)]
+
+if (!exists("skills_cache_dir")) skills_cache_dir <- file.path("data-raw", "cache-skills")
+if (!exists("opta_cache_dir")) opta_cache_dir <- file.path("data-raw", "cache-opta")
+sq_skill_path <- file.path(skills_cache_dir, "06_seasonal_ratings.rds")
+sq_raw_path   <- file.path(opta_cache_dir, "07_seasonal_ratings.rds")
+sq_seasonal <- if (file.exists(sq_skill_path)) {
+  readRDS(sq_skill_path)
+} else if (file.exists(sq_raw_path)) {
+  readRDS(sq_raw_path)
+} else {
+  NULL
+}
+sq_psr <- if (!is.null(sq_seasonal) && !is.null(sq_seasonal$seasonal_psr) &&
+              nrow(sq_seasonal$seasonal_psr) > 0) {
+  p <- as.data.table(sq_seasonal$seasonal_psr)
+  p[order(player_id, -season_end_year), .SD[1L], by = player_id, .SDcols = "psr"]
+} else NULL
+
+sq_epr <- {
+  ep <- file.path(opta_data_dir(), "opta_epr_weekly.parquet")
+  if (file.exists(ep)) {
+    e <- as.data.table(read_parquet(ep))
+    e[, snapshot_date := as.Date(snapshot_date)]
+    e[order(player_id, -snapshot_date), .SD[1L], by = player_id, .SDcols = "epr"]
+  } else NULL
+}
+
+.wsum <- function(x, w) sum(w * data.table::fifelse(is.na(x), 0, x))
+
+teams <- team_league$team
+agg_rows <- vector("list", length(teams))
+for (i in seq_along(teams)) {
+  tm <- teams[i]
+  lu_team <- if (tm %in% lu_known_teams) lu_all[.(tm)] else lu_all[0L]
+  em <- panna::build_team_expected_minutes(
+    team = tm, lineups = lu_team, as_of = as_of_domestic,
+    international_only = FALSE
+  )
+  if (is.null(em) || nrow(em) == 0L || !"player_id" %in% names(em)) {
+    agg_rows[[i]] <- data.table::data.table(
+      team = tm, panna = NA_real_, offense = NA_real_, defense = NA_real_,
+      epr = NA_real_, psr = NA_real_, squad_n = 0L, n_rated = 0L)
+    next
+  }
+  em <- data.table::as.data.table(em)
+  em <- merge(em[, .(player_id, expected_minutes_norm)], sq_panna, by = "player_id", all.x = TRUE)
+  if (!is.null(sq_psr)) em <- merge(em, sq_psr, by = "player_id", all.x = TRUE)
+  if (!is.null(sq_epr)) em <- merge(em, sq_epr, by = "player_id", all.x = TRUE)
+  for (col in c("panna", "offense", "defense", "epr", "psr"))
+    if (!col %in% names(em)) em[[col]] <- NA_real_
+
+  w <- em$expected_minutes_norm / 90
+  agg_rows[[i]] <- data.table::data.table(
+    team = tm,
+    panna   = .wsum(em$panna,   w),
+    offense = .wsum(em$offense, w),
+    defense = .wsum(em$defense, w),
+    epr     = .wsum(em$epr,     w),
+    psr     = .wsum(em$psr,     w),
+    squad_n = nrow(em),
+    n_rated = sum(!is.na(em$panna))
+  )
+}
+agg <- data.table::rbindlist(agg_rows)
+
+strength <- merge(team_league, agg, by = "team", all.x = TRUE)
+for (m in c("panna", "offense", "defense", "epr", "psr", "elo")) {
+  strength[[m]] <- round(strength[[m]], 4)
+}
+# Published convention: defence positive = good (internal model negative = good).
+strength[, defense := -defense]
+
+strength <- .compute_tiento(strength, TIENTO_WEIGHTS)
+
+.validate_domestic_strength(strength)
+
+# 5. Stamp build_id, order columns, write ----
+
+.build_id_val <- .vb_generation_stamp()
+strength[, build_id := .build_id_val]
+
+# Explicit column selection (not a blind setcolorder pass-through) so an
+# internal-only field (cur_sey, used only to pick the relegated cohort) never
+# leaks into the published schema by accident. seed_method is kept -- it is
+# the "why" behind elo_seeded and cheap forensic value for a wrong-looking
+# seed on the blog side.
+strength <- strength[, .(
+  team, league, panna, offense, defense, epr, psr, elo,
+  tiento, rank_tiento, squad_n, n_rated, elo_seeded, seed_method,
+  is_domestic_league, build_id)]
+data.table::setorder(strength, -tiento)
+
+out_path <- file.path(cache_dir, "team_strength.parquet")
+write_parquet(strength, out_path)
+csv_path <- sub("\\.parquet$", ".csv", out_path)
+write.csv(strength, csv_path, row.names = FALSE)
+message(sprintf("  team_strength.parquet: %d teams (build_id=%s)", nrow(strength), .build_id_val))
+
+# 6. Register for step-13 publish (registers ONLY at the very end, after every
+#    write above has succeeded -- deliberately, same reasoning as step 12: a
+#    mid-step failure must register nothing rather than a half-written file) ----
+
+if (exists("publish_files", envir = .GlobalEnv)) {
+  publish_files$blog_latest <<- c(publish_files$blog_latest, out_path, csv_path)
+  message("  Registered team_strength.parquet (+ CSV) for blog-latest publish (step 13).")
+} else {
+  message("  (standalone run -- not registered for step-13 publish)")
+}
+
+message("\n=== Domestic + cup team strength export complete ===")
+
+}  # end DOMESTIC_TEAM_STRENGTH_SOURCE_ONLY guard

--- a/data-raw/match-predictions-opta/run_predictions_opta.R
+++ b/data-raw/match-predictions-opta/run_predictions_opta.R
@@ -68,6 +68,7 @@ if (!exists("run_steps", inherits = FALSE)) {
     step_12_export_wc2026_blog       = FALSE,  # Opt-in: export WC2026 blog data
     step_12b_snapshot_wc_minutes     = FALSE,  # Opt-in: archive dated minutes snapshot + diff
     step_12c_snapshot_wc_strength    = FALSE,  # Opt-in: archive dated team-strength (ELO+p_champ) snapshot + diff
+    step_12d_export_domestic_team_strength = FALSE,  # Opt-in: export Tiento for every domestic/cup club (panna#193)
     step_13_publish_release_data     = FALSE   # Opt-in: single gated publish of predictions-latest + blog-latest (PA5/H-TORN)
   )
 }
@@ -493,6 +494,25 @@ step_results[["12c"]] <- run_pred_step_optional("snapshot_wc_strength", "12c", f
   source("data-raw/match-predictions-opta/12c_snapshot_wc_strength.R", local = TRUE)
 })
 
+# 14g2. Step 12d: Export Domestic + Cup Team Strength (Tiento, all clubs) ----
+# Domestic sibling of step 12 (panna#193): every team in the current fixture
+# window, not just the WC2026 48 -- Tiento becomes the headline team rating
+# everywhere, as Piero already is for players.
+#
+# NON-FATAL (run_pred_step_optional), for the SAME reason step 12 is: it
+# registers team_strength.parquet in publish_files only at its very own end
+# (12d:...), after every write has already succeeded, so a mid-step failure
+# registers nothing for step 13 to publish -- there is no half-written file
+# to protect the release from. Depends on step 4 (Elo -- though this step
+# re-derives final_elos itself; see the comment in 12d for why) and on the
+# rating-source files (career_panna.parquet, opta_epr_weekly.parquet, the
+# seasonal-ratings caches) already being on disk, same prerequisites as
+# step 12 section 5. Placed after 12c so it runs alongside its WC sibling.
+
+step_results[["12d"]] <- run_pred_step_optional("export_domestic_team_strength", "12d", function() {
+  source("data-raw/match-predictions-opta/12d_export_domestic_team_strength.R", local = TRUE)
+})
+
 # 14h. Step 13: Publish predictions-latest + blog-latest (gated, manifest-last) ----
 # Runs after every build step so publish_files is fully populated. A failure
 # here (e.g. one tag's vb_publish aborting) is caught by run_pipeline_step() like
@@ -536,6 +556,10 @@ if (isTRUE(run_steps$step_12_export_wc2026_blog)) {
   message(sprintf("  - %s", file.path(cache_dir, "wc2026_predictions.parquet")))
   message(sprintf("  - %s", file.path(cache_dir, "wc2026_team_strength.parquet")))
   message("  - (wc2026_*.parquet uploaded to blog-latest)")
+}
+if (isTRUE(run_steps$step_12d_export_domestic_team_strength)) {
+  message(sprintf("  - %s", file.path(cache_dir, "team_strength.parquet")))
+  message("  - (team_strength.parquet uploaded to blog-latest)")
 }
 
 message("\nDone!")

--- a/tests/testthat/test-domestic-team-strength.R
+++ b/tests/testthat/test-domestic-team-strength.R
@@ -1,0 +1,543 @@
+# Tests for 12d_export_domestic_team_strength.R (panna#193).
+#
+# Domestic sibling of 12_export_wc2026_blog.R section 5: Tiento for every
+# club in the current fixture window (domestic-league AND cup-only), not just
+# the WC2026 48. Two things are genuinely new versus the WC exporter and get
+# the most coverage here:
+#   1. Elo seeding for teams with no tracked history (promoted from a
+#      division panna doesn't scrape) -- the measured relegated-cohort rule.
+#   2. Classifying every team as domestic-league vs cup-only, pinning a
+#      dual-labelled team (domestic + continental cup this season) to its
+#      domestic league.
+#
+# `.mocked_bindings` style: local_no_reload() stubs devtools::load_all()
+# before sourcing, same helper test-wc2026-export.R and
+# test-match-features-export.R already use (the script's own load_all() call
+# would otherwise reload the package namespace mid-suite).
+
+local_no_reload <- function(env = parent.frame()) {
+  if (!requireNamespace("devtools", quietly = TRUE)) return(invisible(NULL))
+  testthat::local_mocked_bindings(
+    load_all = function(...) invisible(NULL), .package = "devtools", .env = env)
+}
+
+.dts_script <- function() {
+  testthat::test_path("..", "..", "data-raw", "match-predictions-opta",
+                      "12d_export_domestic_team_strength.R")
+}
+
+# --- Source-only helper: get the pure functions without any I/O fixtures ---
+# `env` defaults to the CALLER's frame (the enclosing test_that() block) so
+# local_no_reload()'s withr::defer un-mocks devtools::load_all() when that
+# frame exits -- same lifetime local_no_reload() gets when test files call it
+# directly, per test-wc2026-export.R's own comment on why this matters
+# (load_all() reloading the package mid-suite breaks every later test file).
+.dts_source_only <- function(env = parent.frame()) {
+  script <- .dts_script()
+  testthat::skip_if_not(file.exists(script), "12d script not found")
+  local_no_reload(env)
+  e <- new.env(parent = globalenv())
+  assign("DOMESTIC_TEAM_STRENGTH_SOURCE_ONLY", TRUE, envir = e)
+  source(script, local = e)
+  e
+}
+
+# ============================================================
+# .classify_team_leagues()
+# ============================================================
+
+test_that("dual-labelled team is pinned to its domestic league, not its cup", {
+  e <- .dts_source_only()
+  fr <- data.table::data.table(
+    league  = c("ENG", "ENG", "UCL"),
+    season_end_year = c(2027, 2027, 2027),
+    home_team = c("TeamA", "TeamB", "TeamA"),
+    away_team = c("TeamB", "TeamA", "CupOnlyClub"),
+    match_status = "Played"
+  )
+  out <- e$.classify_team_leagues(fr, domestic_codes = "ENG", cup_codes = "UCL")
+  a <- out[team == "TeamA"]
+  expect_equal(a$league, "ENG")
+  expect_true(a$is_domestic_league)
+  cup <- out[team == "CupOnlyClub"]
+  expect_equal(cup$league, "UCL")
+  expect_false(cup$is_domestic_league)
+})
+
+test_that("current season is picked PER LEAGUE, not globally", {
+  # ENG's latest season_end_year (2028) is ahead of SCO's (2027) -- SCO's
+  # roster must use ITS OWN latest season, not get dragged to 2028 and come
+  # back empty.
+  e <- .dts_source_only()
+  fr <- data.table::data.table(
+    league  = c("ENG", "ENG", "SCO"),
+    season_end_year = c(2027, 2028, 2027),
+    home_team = c("TeamA", "TeamA", "ScoX"),
+    away_team = c("TeamB", "TeamB", "ScoY"),
+    match_status = "Played"
+  )
+  out <- e$.classify_team_leagues(fr, domestic_codes = c("ENG", "SCO"), cup_codes = "UCL")
+  expect_equal(out[team == "TeamA"]$cur_sey, 2028)
+  expect_equal(out[team == "ScoX"]$cur_sey, 2027)
+  expect_true(all(c("ScoX", "ScoY") %in% out$team))
+})
+
+test_that("a team appearing in NO scope league is simply absent from the output", {
+  e <- .dts_source_only()
+  fr <- data.table::data.table(
+    league  = c("ENG", "WC"),
+    season_end_year = c(2027, 2027),
+    home_team = c("TeamA", "France"),
+    away_team = c("TeamB", "Brazil"),
+    match_status = "Played"
+  )
+  out <- e$.classify_team_leagues(fr, domestic_codes = "ENG", cup_codes = "UCL")
+  expect_false(any(c("France", "Brazil") %in% out$team))
+})
+
+# ============================================================
+# .relegated_cohort()
+# ============================================================
+
+test_that("relegated cohort is last season's teams minus this season's", {
+  e <- .dts_source_only()
+  fr <- data.table::data.table(
+    league = "ENG",
+    season_end_year = c(2026, 2026, 2026, 2027, 2027),
+    home_team = c("TeamA", "TeamB", "OldBad", "TeamA", "TeamB"),
+    away_team = c("TeamB", "OldBad", "TeamA", "TeamB", "TeamA"),
+    match_status = "Played"
+  )
+  out <- e$.relegated_cohort(fr, "ENG", cur_sey = 2027)
+  expect_setequal(out, "OldBad")
+})
+
+test_that("no prior season at all -> empty relegated cohort (not an error)", {
+  e <- .dts_source_only()
+  fr <- data.table::data.table(
+    league = "ENG", season_end_year = 2027,
+    home_team = "TeamA", away_team = "TeamB", match_status = "Played"
+  )
+  out <- e$.relegated_cohort(fr, "ENG", cur_sey = 2027)
+  expect_equal(out, character(0))
+})
+
+# ============================================================
+# .seed_missing_elo() -- the measured rule
+# ============================================================
+
+test_that("a promoted team is seeded at the relegated cohort's mean final Elo", {
+  e <- .dts_source_only()
+  fr <- data.table::data.table(
+    league = c("ENG", "ENG", "ENG"),
+    season_end_year = c(2026, 2026, 2027),
+    home_team = c("TeamA", "OldBad", "TeamA"),
+    away_team = c("OldBad", "TeamA", "TeamB"),
+    match_status = "Played"
+  )
+  team_league <- data.table::data.table(
+    team = c("TeamA", "OldBad", "NewClub"),
+    league = "ENG", is_domestic_league = TRUE, cur_sey = 2027
+  )
+  final_elos <- c(TeamA = 1550, OldBad = 1420)  # NewClub absent -- no history
+  out <- e$.seed_missing_elo(final_elos, team_league, fr)
+
+  nc <- out[team == "NewClub"]
+  expect_true(nc$elo_seeded)
+  expect_equal(nc$seed_method, "relegated_cohort")
+  expect_equal(nc$seed_n, 1L)
+  expect_equal(nc$elo, 1420)  # mean of a single-team cohort is that team's own Elo
+
+  earned <- out[team == "TeamA"]
+  expect_false(earned$elo_seeded)
+  expect_equal(earned$seed_method, "earned")
+  expect_equal(earned$elo, 1550)
+})
+
+test_that("mean of a MULTI-team relegated cohort, not just the first", {
+  e <- .dts_source_only()
+  team_league <- data.table::data.table(
+    team = "NewClub", league = "ENG", is_domestic_league = TRUE, cur_sey = 2027
+  )
+  fr <- data.table::data.table(
+    league = "ENG", season_end_year = 2026,
+    home_team = c("Bad1", "Bad2"), away_team = c("Bad2", "Bad1"),
+    match_status = "Played"
+  )
+  final_elos <- c(Bad1 = 1400, Bad2 = 1500)
+  out <- e$.seed_missing_elo(final_elos, team_league, fr)
+  expect_equal(out$elo, 1450)  # mean(1400, 1500)
+  expect_equal(out$seed_n, 2L)
+})
+
+test_that("no identifiable relegated cohort falls back to the league mean, and says so", {
+  e <- .dts_source_only()
+  # No prior ENG season at all in fr -- .relegated_cohort() returns empty.
+  fr <- data.table::data.table(
+    league = "ENG", season_end_year = 2027,
+    home_team = "PeerA", away_team = "PeerB", match_status = "Played"
+  )
+  team_league <- data.table::data.table(
+    team = c("PeerA", "PeerB", "NewClub"),
+    league = "ENG", is_domestic_league = TRUE, cur_sey = 2027
+  )
+  final_elos <- c(PeerA = 1600, PeerB = 1400)  # NewClub absent
+  expect_message(
+    out <- e$.seed_missing_elo(final_elos, team_league, fr),
+    "no identifiable relegated cohort"
+  )
+  nc <- out[team == "NewClub"]
+  expect_equal(nc$seed_method, "league_mean_fallback")
+  expect_equal(nc$elo, 1500)  # mean(1600, 1400)
+})
+
+test_that("a cup-only team with no history falls back to the cup's peer mean (no relegation concept)", {
+  e <- .dts_source_only()
+  team_league <- data.table::data.table(
+    team = c("CupPeer", "CupNewbie"),
+    league = "UCL", is_domestic_league = FALSE, cur_sey = 2027
+  )
+  fr <- data.table::data.table(
+    league = "UCL", season_end_year = 2027,
+    home_team = "CupPeer", away_team = "SomeoneElse", match_status = "Played"
+  )
+  final_elos <- c(CupPeer = 1650)  # CupNewbie absent
+  out <- e$.seed_missing_elo(final_elos, team_league, fr)
+  newbie <- out[team == "CupNewbie"]
+  expect_true(newbie$elo_seeded)
+  expect_equal(newbie$seed_method, "league_mean_fallback_cup")
+  expect_equal(newbie$elo, 1650)
+})
+
+test_that("no cohort AND no peers leaves Elo NA with a loud warning (never silently 1500)", {
+  e <- .dts_source_only()
+  team_league <- data.table::data.table(
+    team = "Lonely", league = "ZZZ", is_domestic_league = TRUE, cur_sey = 2027
+  )
+  fr <- data.table::data.table(
+    league = character(0), season_end_year = numeric(0),
+    home_team = character(0), away_team = character(0), match_status = character(0)
+  )
+  final_elos <- c(SomeoneUnrelated = 1500)
+  expect_message(
+    out <- e$.seed_missing_elo(final_elos, team_league, fr),
+    "no relegated cohort AND no league-mean peers"
+  )
+  expect_true(is.na(out$elo))
+  expect_true(out$elo_seeded)
+  # Never falls back to the bare ELO_INITIAL default -- confirms it stayed NA,
+  # not silently 1500.
+  expect_false(isTRUE(out$elo == 1500))
+})
+
+# ============================================================
+# .compute_tiento() -- global z-score pool
+# ============================================================
+
+test_that("tiento is a weighted sum of GLOBAL z-scores, and ranks correctly", {
+  e <- .dts_source_only()
+  dt <- data.table::data.table(
+    team = c("Strong", "Mid", "Weak"),
+    panna = c(2, 0, -2), epr = c(1, 0, -1), elo = c(1600, 1500, 1400), psr = c(0.5, 0, -0.5)
+  )
+  out <- e$.compute_tiento(dt, weights = c(panna = 0.4, epr = 0.2, elo = 0.3, psr = 0.1))
+  # Strong is above the pool mean on every metric -> highest tiento, rank 1.
+  expect_equal(out[team == "Strong"]$rank_tiento, 1L)
+  expect_equal(out[team == "Weak"]$rank_tiento, 3L)
+  expect_true(out[team == "Strong"]$tiento > out[team == "Mid"]$tiento)
+  expect_true(out[team == "Mid"]$tiento > out[team == "Weak"]$tiento)
+  # Mid sits exactly at the pool mean on every metric -> z=0 on all four -> tiento 0.
+  expect_equal(out[team == "Mid"]$tiento, 0)
+})
+
+test_that("a constant column contributes zero (no NaN from sd=0), not an error", {
+  e <- .dts_source_only()
+  dt <- data.table::data.table(
+    team = c("A", "B"), panna = c(1, 1), epr = c(1, -1), elo = c(1500, 1500), psr = c(0, 0)
+  )
+  out <- e$.compute_tiento(dt, weights = c(panna = 0.4, epr = 0.2, elo = 0.3, psr = 0.1))
+  expect_false(anyNA(out$tiento))
+})
+
+# ============================================================
+# .validate_domestic_strength() -- mutation-tested guards
+# ============================================================
+
+.dts_good_strength <- function() {
+  data.table::data.table(
+    team = c("A", "B", "C"),
+    league = c("ENG", "ENG", "UCL"),
+    panna = c(1, 0.5, -0.5), epr = c(1, 0.5, -0.5), psr = c(1, 0.5, -0.5),
+    elo = c(1600, 1500, 1400),
+    tiento = c(2, 0, -2),
+    squad_n = c(20L, 18L, 22L)
+  )
+}
+
+test_that("guard: every team must have a league", {
+  e <- .dts_source_only()
+  good <- .dts_good_strength()
+  expect_no_error(suppressMessages(e$.validate_domestic_strength(good, min_squad_n = 5L)))
+
+  bad <- data.table::copy(good)
+  bad$league[2] <- NA_character_
+  expect_error(e$.validate_domestic_strength(bad, min_squad_n = 5L), "no league")
+
+  # Revert: passes again.
+  expect_no_error(suppressMessages(e$.validate_domestic_strength(good, min_squad_n = 5L)))
+})
+
+test_that("guard: every team must have non-NA tiento", {
+  e <- .dts_source_only()
+  good <- .dts_good_strength()
+  expect_no_error(suppressMessages(e$.validate_domestic_strength(good, min_squad_n = 5L)))
+
+  bad <- data.table::copy(good)
+  bad$tiento[1] <- NA_real_
+  expect_error(e$.validate_domestic_strength(bad, min_squad_n = 5L), "NA tiento")
+
+  expect_no_error(suppressMessages(e$.validate_domestic_strength(good, min_squad_n = 5L)))
+})
+
+test_that("guard: elo must be non-NA (post-seeding) for every team", {
+  e <- .dts_source_only()
+  good <- .dts_good_strength()
+  expect_no_error(suppressMessages(e$.validate_domestic_strength(good, min_squad_n = 5L)))
+
+  bad <- data.table::copy(good)
+  bad$elo[3] <- NA_real_
+  expect_error(e$.validate_domestic_strength(bad, min_squad_n = 5L), "elo missing")
+
+  expect_no_error(suppressMessages(e$.validate_domestic_strength(good, min_squad_n = 5L)))
+})
+
+test_that("guard: a 2-player squad is a broken join, not a small squad", {
+  e <- .dts_source_only()
+  good <- .dts_good_strength()
+  expect_no_error(suppressMessages(e$.validate_domestic_strength(good, min_squad_n = 5L)))
+
+  bad <- data.table::copy(good)
+  bad$squad_n[1] <- 2L
+  expect_error(e$.validate_domestic_strength(bad, min_squad_n = 5L), "broken team_name join")
+
+  expect_no_error(suppressMessages(e$.validate_domestic_strength(good, min_squad_n = 5L)))
+})
+
+test_that("guard: panna/epr/psr zero (or all-NA) for >=50% of teams refuses to publish", {
+  e <- .dts_source_only()
+  good <- .dts_good_strength()
+  expect_no_error(suppressMessages(e$.validate_domestic_strength(good, min_squad_n = 5L)))
+
+  bad <- data.table::copy(good)
+  bad$panna <- c(0, 0, -0.5)  # 2/3 zero
+  expect_error(e$.validate_domestic_strength(bad, min_squad_n = 5L), "rating-join failure")
+
+  # And the ALL-NA variant (a metric nobody joined at all) must not crash on
+  # NaN from an empty na.rm mean -- it must still refuse, not error out with
+  # "missing value where TRUE/FALSE needed" or silently pass.
+  bad_na <- data.table::copy(good)
+  bad_na$epr <- NA_real_
+  expect_error(e$.validate_domestic_strength(bad_na, min_squad_n = 5L), "rating-join failure")
+
+  expect_no_error(suppressMessages(e$.validate_domestic_strength(good, min_squad_n = 5L)))
+})
+
+# ============================================================
+# End-to-end: source() the whole script against a small real fixture set
+# ============================================================
+
+.dts_full_fixture <- function(cache_dir, opta_dir, skills_dir) {
+  dir.create(opta_dir, recursive = TRUE, showWarnings = FALSE)
+  dir.create(skills_dir, recursive = TRUE, showWarnings = FALSE)
+
+  # --- fixture_results: ENG (2 seasons, 1 relegation), SCO (1 season, no
+  # prior season at all), UCL (cup-only + one dual-labelled team: TeamA) ---
+  mk <- function(id, date, league, season, sey, home, away, hg, ag, status = "Played") {
+    data.frame(match_id = id, match_date = as.character(date), match_status = status,
+              league = league, season = season, season_end_year = sey,
+              home_team = home, away_team = away,
+              home_team_id = paste0("id_", home), away_team_id = paste0("id_", away),
+              home_goals = hg, away_goals = ag, home_xg = NA_real_, away_xg = NA_real_,
+              result = if (is.na(hg)) NA_character_ else if (hg > ag) "H" else if (hg == ag) "D" else "A",
+              is_neutral_venue = 0L, stringsAsFactors = FALSE)
+  }
+  fr <- rbind(
+    # ENG season 2025-2026 (sey=2026): TeamA/TeamB/TeamC/OldBad all played.
+    mk("m1", "2025-09-01", "ENG", "2025-2026", 2026, "TeamA", "TeamB", 2, 1),
+    mk("m2", "2025-09-08", "ENG", "2025-2026", 2026, "TeamB", "OldBad", 0, 2),
+    mk("m3", "2025-09-15", "ENG", "2025-2026", 2026, "OldBad", "TeamC", 1, 1),
+    mk("m4", "2025-09-22", "ENG", "2025-2026", 2026, "TeamC", "TeamA", 0, 3),
+    # ENG season 2026-2027 (sey=2027): OldBad absent (relegated), NewClub
+    # present only via an upcoming fixture (zero played history anywhere).
+    mk("m6", "2026-08-20", "ENG", "2026-2027", 2027, "TeamA", "TeamB", 1, 1),
+    mk("m7", "2026-08-27", "ENG", "2026-2027", 2027, "TeamB", "TeamC", 2, 0),
+    mk("m8", "2026-09-03", "ENG", "2026-2027", 2027, "TeamC", "TeamA", 1, 2),
+    mk("m5", "2026-10-05", "ENG", "2026-2027", 2027, "NewClub", "TeamA", NA, NA, status = "Fixture"),
+    # SCO: only ONE tracked season -- no prior season exists at all, so
+    # ScoTeamZ (promoted, zero history) must hit the league-mean fallback.
+    mk("m12", "2026-08-10", "SCO", "2026-2027", 2027, "ScoTeamX", "ScoTeamY", 1, 0),
+    mk("m13", "2026-08-24", "SCO", "2026-2027", 2027, "ScoTeamZ", "ScoTeamX", NA, NA, status = "Fixture"),
+    # UCL: TeamA is dual-labelled (also ENG) -- must pin to ENG. CupOnlyClub2
+    # has real UCL history (earned Elo); CupOnlyClub is cup-only with zero
+    # history (must hit the cup's league-mean fallback, i.e. CupOnlyClub2).
+    mk("m9", "2026-09-10", "UCL", "2026-2027", 2027, "TeamA", "CupOnlyClub2", 2, 0),
+    mk("m11", "2026-10-01", "UCL", "2026-2027", 2027, "CupOnlyClub", "CupOnlyClub2", NA, NA, status = "Fixture")
+  )
+  saveRDS(fr, file.path(cache_dir, "01_fixture_results.rds"))
+
+  # --- opta_lineups.parquet: 4 players per team, one match each ---
+  teams <- c("TeamA", "TeamB", "TeamC", "NewClub", "ScoTeamX", "ScoTeamY",
+            "ScoTeamZ", "CupOnlyClub", "CupOnlyClub2")
+  lu_rows <- list()
+  pid <- 1L
+  for (tm in teams) {
+    for (j in 1:4) {
+      lu_rows[[length(lu_rows) + 1L]] <- data.frame(
+        team_name = tm, match_id = paste0("lu_", tm), match_date = "2026-09-01T00:00:00Z",
+        player_id = sprintf("p%03d", pid), player_name = sprintf("Player %d", pid),
+        position = c("Goalkeeper", "Centre Back", "Central Midfielder", "Striker")[j],
+        is_starter = TRUE, minutes_played = 90L, competition = "Domestic",
+        stringsAsFactors = FALSE)
+      pid <- pid + 1L
+    }
+  }
+  lu <- do.call(rbind, lu_rows)
+  arrow::write_parquet(lu, file.path(opta_dir, "opta_lineups.parquet"))
+
+  # --- career_panna.parquet / opta_epr_weekly.parquet / seasonal PSR: every
+  # player gets a distinct, nonzero rating so no zero-tripwire guard fires. ---
+  player_ids <- unique(lu$player_id)
+  n <- length(player_ids)
+  cp <- data.frame(player_id = player_ids,
+                   panna = seq(0.1, by = 0.05, length.out = n),
+                   panna_offense = seq(0.2, by = 0.05, length.out = n),
+                   panna_defense = seq(-0.1, by = -0.02, length.out = n),
+                   total_minutes = 900, stringsAsFactors = FALSE)
+  arrow::write_parquet(cp, file.path(opta_dir, "career_panna.parquet"))
+
+  epr <- data.frame(player_id = player_ids, snapshot_date = "2026-09-15",
+                    epr = seq(0.05, by = 0.02, length.out = n), stringsAsFactors = FALSE)
+  arrow::write_parquet(epr, file.path(opta_dir, "opta_epr_weekly.parquet"))
+
+  seasonal_psr <- data.frame(player_id = player_ids, season_end_year = 2027,
+                             psr = seq(0.15, by = 0.03, length.out = n), stringsAsFactors = FALSE)
+  saveRDS(list(seasonal_psr = seasonal_psr), file.path(skills_dir, "06_seasonal_ratings.rds"))
+
+  invisible(NULL)
+}
+
+.run_12d <- function(cache_dir, opta_dir, skills_dir, publish = TRUE) {
+  script <- .dts_script()
+  testthat::skip_if_not(file.exists(script), "12d script not found")
+  if (publish) {
+    assign("publish_files",
+          list(predictions_latest = character(0), blog_latest = character(0)),
+          envir = globalenv())
+  } else if (exists("publish_files", envir = globalenv())) {
+    rm("publish_files", envir = globalenv())
+  }
+  old_opta_dir <- tryCatch(opta_data_dir(), error = function(e) NULL)
+  opta_data_dir(opta_dir)
+  on.exit({
+    if (!is.null(old_opta_dir)) opta_data_dir(old_opta_dir)
+  }, add = TRUE)
+
+  # Same "runner inside a closure reaching globalenv" trick 04b's test uses --
+  # required for the script's `publish_files$... <<-` to find the accumulator.
+  runner <- function() source(script, local = TRUE)
+  environment(runner) <- list2env(
+    list(cache_dir = cache_dir, script = script,
+        domestic_codes = c("ENG", "SCO"), cup_codes = "UCL",
+        as_of_domestic = as.Date("2026-10-15"),
+        MIN_PLAUSIBLE_SQUAD_N = 3L,
+        skills_cache_dir = skills_dir,
+        opta_cache_dir = file.path(skills_dir, "..", "cache-opta")),
+    parent = globalenv())
+  runner()
+  invisible(NULL)
+}
+
+test_that("12d exports Tiento for every team, seeds Elo correctly, and pins dual labels", {
+  skip_if_not_installed("arrow")
+  local_no_reload()
+  cache_dir <- withr::local_tempdir()
+  opta_dir <- withr::local_tempdir()
+  skills_dir <- withr::local_tempdir()
+  .dts_full_fixture(cache_dir, opta_dir, skills_dir)
+  on.exit(suppressWarnings(rm("publish_files", envir = globalenv())), add = TRUE)
+
+  .run_12d(cache_dir, opta_dir, skills_dir)
+
+  out <- arrow::read_parquet(file.path(cache_dir, "team_strength.parquet"))
+  expect_equal(nrow(out), 9L)
+  expect_setequal(out$team, c("TeamA", "TeamB", "TeamC", "NewClub",
+                              "ScoTeamX", "ScoTeamY", "ScoTeamZ",
+                              "CupOnlyClub", "CupOnlyClub2"))
+
+  # Dual-labelled team pinned to its domestic league.
+  a <- out[out$team == "TeamA", ]
+  expect_equal(a$league, "ENG")
+  expect_true(a$is_domestic_league)
+
+  # Cup-only team correctly flagged.
+  cup <- out[out$team == "CupOnlyClub2", ]
+  expect_equal(cup$league, "UCL")
+  expect_false(cup$is_domestic_league)
+
+  # Elo seeding fired for exactly the three teams with no tracked history.
+  seeded <- out[out$elo_seeded, ]
+  expect_setequal(seeded$team, c("NewClub", "ScoTeamZ", "CupOnlyClub"))
+  expect_equal(seeded$seed_method[seeded$team == "NewClub"], "relegated_cohort")
+  expect_equal(seeded$seed_method[seeded$team == "ScoTeamZ"], "league_mean_fallback")
+  expect_equal(seeded$seed_method[seeded$team == "CupOnlyClub"], "league_mean_fallback_cup")
+  # Every non-seeded team is "earned".
+  expect_true(all(out$seed_method[!out$elo_seeded] == "earned"))
+
+  # No NA anywhere in the columns a publish depends on.
+  expect_false(anyNA(out$elo))
+  expect_false(anyNA(out$tiento))
+  expect_false(anyNA(out$league))
+
+  # Squad size sane (4 players each in the fixture).
+  expect_true(all(out$squad_n == 4L))
+
+  # build_id stamped identically across the one file this step writes.
+  expect_true(all(nzchar(out$build_id)))
+})
+
+test_that("12d registers the parquet + CSV for blog-latest publish, only at the very end", {
+  skip_if_not_installed("arrow")
+  local_no_reload()
+  cache_dir <- withr::local_tempdir()
+  opta_dir <- withr::local_tempdir()
+  skills_dir <- withr::local_tempdir()
+  .dts_full_fixture(cache_dir, opta_dir, skills_dir)
+  on.exit(suppressWarnings(rm("publish_files", envir = globalenv())), add = TRUE)
+
+  .run_12d(cache_dir, opta_dir, skills_dir)
+  pf <- get("publish_files", envir = globalenv())
+  expect_length(pf$blog_latest, 2L)
+  expect_true(any(grepl("team_strength[.]parquet$", pf$blog_latest)))
+  expect_true(any(grepl("team_strength[.]csv$", pf$blog_latest)))
+  # It is blog data, not a predictions-pipeline diagnostic.
+  expect_length(pf$predictions_latest, 0L)
+})
+
+test_that("12d aborts rather than shipping a team with an impossible squad (integration-level guard)", {
+  skip_if_not_installed("arrow")
+  local_no_reload()
+  cache_dir <- withr::local_tempdir()
+  opta_dir <- withr::local_tempdir()
+  skills_dir <- withr::local_tempdir()
+  .dts_full_fixture(cache_dir, opta_dir, skills_dir)
+  on.exit(suppressWarnings(rm("publish_files", envir = globalenv())), add = TRUE)
+
+  # Break the join for one team: drop its lineup rows entirely (opta_lineups
+  # drift / team_name mismatch), same failure shape the guard exists to catch.
+  lu <- arrow::read_parquet(file.path(opta_dir, "opta_lineups.parquet"), mmap = FALSE)
+  lu <- lu[lu$team_name != "TeamB", ]
+  arrow::write_parquet(lu, file.path(opta_dir, "opta_lineups.parquet"))
+
+  expect_error(.run_12d(cache_dir, opta_dir, skills_dir, publish = FALSE),
+              "broken team_name join")
+})

--- a/tests/testthat/test-domestic-team-strength.R
+++ b/tests/testthat/test-domestic-team-strength.R
@@ -588,4 +588,32 @@ test_that("12d's Elo literals still match 03_team_rolling_features.R", {
   expect_match(call_line, "k = 20", fixed = TRUE)
   expect_match(call_line, "home_advantage = 88", fixed = TRUE)
   expect_match(call_line, "initial_elo = 1500", fixed = TRUE)
+
+  # use_venue_factor too: it has already been flipped once (FALSE -> TRUE), so
+  # it is demonstrably a thing that changes. Both sites hardcode TRUE today.
+  # Match the ARGUMENT, not any mention -- step 3 also names it in a comment
+  # recording the FALSE -> TRUE change, which is itself the evidence that this
+  # value moves.
+  arg_of <- function(lines) {
+    hit <- grep("^[[:space:]]*use_venue_factor[[:space:]]*=", lines, value = TRUE)
+    if (!length(hit)) return(NA_character_)
+    trimws(sub(".*=", "", hit[1]))
+  }
+  expect_identical(arg_of(readLines(step3, warn = FALSE)), arg_of(src))
+})
+
+test_that("12d asks build_team_expected_minutes for the same window the WC path does", {
+  # The WC squads are built with lookback_days = 1095L; the library default is
+  # 730L. Taking the default here would make a domestic Tiento mean something
+  # different from a WC Tiento while the header claimed they matched -- which
+  # is what review found on the first version.
+  sq <- testthat::test_path("..", "..", "data-raw", "match-predictions-opta",
+                            "announced_squads.R")
+  step12d <- testthat::test_path("..", "..", "data-raw", "match-predictions-opta",
+                                 "12d_export_domestic_team_strength.R")
+  skip_if_not(file.exists(sq) && file.exists(step12d), "pipeline scripts not present")
+  wc_windows <- unique(trimws(grep("lookback_days", readLines(sq, warn = FALSE), value = TRUE)))
+  expect_true(all(grepl("1095", wc_windows)))
+  expect_true(any(grepl("lookback_days = 1095L",
+                        readLines(step12d, warn = FALSE), fixed = TRUE)))
 })

--- a/tests/testthat/test-domestic-team-strength.R
+++ b/tests/testthat/test-domestic-team-strength.R
@@ -541,3 +541,51 @@ test_that("12d aborts rather than shipping a team with an impossible squad (inte
   expect_error(.run_12d(cache_dir, opta_dir, skills_dir, publish = FALSE),
               "broken team_name join")
 })
+
+
+# --- Elo-constant drift guard -----------------------------------------------
+# 12d re-derives final_elos by duplicating 03_team_rolling_features.R's
+# compute_match_elos() call, because step 3 keeps only the per-match features it
+# derives and never persists the team-state vector a relegated cohort needs.
+#
+# That duplication is unavoidable today, but "MUST be kept in sync by hand" is
+# exactly the instruction that does not get followed -- this repo has already
+# been bitten by a vendored file drifting, a header comment claiming coverage it
+# no longer had, and a `keep` vector nothing read. If step 3's constants are
+# retuned and 12d's literals are not, domestic Tiento silently uses a DIFFERENT
+# Elo from the one the predictions use, and nothing fails.
+#
+# So assert it instead of asking for it.
+
+test_that("12d's Elo literals still match 03_team_rolling_features.R", {
+  step3 <- testthat::test_path("..", "..", "data-raw", "match-predictions-opta",
+                               "03_team_rolling_features.R")
+  step12d <- testthat::test_path("..", "..", "data-raw", "match-predictions-opta",
+                                 "12d_export_domestic_team_strength.R")
+  skip_if_not(file.exists(step3) && file.exists(step12d), "pipeline scripts not present")
+
+  # regmatches rather than a sub() backreference: this file is written through
+  # shells that mangle backslash escapes, and a broken backreference silently
+  # returns a control character that compares unequal to everything -- which
+  # would make this guard fail for the wrong reason.
+  grab <- function(path, pattern) {
+    ln <- grep(pattern, readLines(path, warn = FALSE), value = TRUE)
+    if (!length(ln)) return(NA_character_)
+    m <- regmatches(ln[1], regexpr("[0-9]+", ln[1]))
+    if (!length(m)) NA_character_ else m
+  }
+
+  expect_identical(grab(step3, "^ELO_K[[:space:]]*<-"),        "20")
+  expect_identical(grab(step3, "^ELO_HOME_ADV[[:space:]]*<-"), "88")
+  expect_identical(grab(step3, "^ELO_INITIAL[[:space:]]*<-"),  "1500")
+
+  src <- readLines(step12d, warn = FALSE)
+  call_line <- grep("k = .*home_advantage = .*initial_elo = ", src, value = TRUE)
+  expect_length(call_line, 1L)
+  # If this fails, step 3 was retuned and 12d was not. Update 12d's literals to
+  # match -- do NOT relax this test. A mismatch means domestic Tiento is built
+  # from a different Elo than the predictions use.
+  expect_match(call_line, "k = 20", fixed = TRUE)
+  expect_match(call_line, "home_advantage = 88", fixed = TRUE)
+  expect_match(call_line, "initial_elo = 1500", fixed = TRUE)
+})


### PR DESCRIPTION
Tiento is currently World Cup only. `football/team-strength.parquet` 404s on R2, and the domestic Team Ratings page still shows the sum of the top 20 players' panna — while `league.qmd`'s Team strength panel says outright that it's "from end-of-last-season ratings — summer transfers are not reflected yet".

New step **12d** publishes `team_strength.parquet`: `team, league, panna, offense, defense, epr, psr, elo, tiento, rank_tiento, squad_n, n_rated, elo_seeded, seed_method, is_domestic_league, build_id`.

Paired with **pannadata#128**, which pulls the file into `blog/` so it can reach R2.

## Three decisions, all Pete's

**Squad aggregation matches the World Cup exactly** — the minutes-weighted formula via `build_team_expected_minutes(international_only = FALSE)`, not the 11-man starting-XI sums already sitting in `match_features.parquet`. So a domestic Tiento means the same thing as a WC Tiento. Weights reused unchanged (panna .40 / epr .20 / elo .30 / psr .10); no re-fit.

**All teams included**, with `is_domestic_league` distinguishing club-league sides from the ~67 that appear only under UCL/UEL/UECL, and dual-labelled teams pinned to their domestic league.

**Teams with no Elo are seeded**, not dropped. Two currently qualify — Le Mans and Elversberg, promoted from Ligue 2 and 2. Bundesliga, which panna doesn't scrape.

## The seeding rule was measured, not chosen

Pete's suggestion: seed a promoted club at the average of the teams relegated the year before. Tested across 57 clean league-seasons:

| rule | mean error | MAE | sd |
|---|---|---|---|
| **average of last season's relegated cohort** | **+15** | **69** | 89 |
| league mean | — | 179 | — |
| `ELO_INITIAL` = 1500 | — | 97 | — |

Essentially unbiased, so no correction term. It's also the only candidate that's self-calibrating per league-season — which matters because Ligue 2 and 2. Bundesliga are unscraped, so no France- or Germany-specific constant can be derived.

The harness is committed at `data-raw/debug/keep/_elo_seed_rule_measurement.R`, because a measured constant nobody can reproduce is a number on trust. It names the trap that produces the wrong answer: **738 of 7,135 club-seasons start at exactly `ELO_INITIAL`**, and leaving them in inflates the measured bias from +15 to +50.

Writing that harness corrected two figures I'd previously quoted — the league-mean alternative is 179 MAE, not ~80. Notably a flat 1500 **beats** the league mean, because the mean is dragged up by strong clubs.

`elo_seeded` and `seed_method` ship as columns: residual sd is 89 on a component worth 30% of Tiento, so the blog can tell a seeded rating from an earned one.

## Review found three things

`code-reviewer`, Sonnet. All fixed in `f3e6c7c1`.

**`lookback_days` broke the parity the header claimed.** 12d took the library default of 730L while `announced_squads.R` passes 1095L at both call sites — so "mirrors the WC EXACTLY" was false on the one parameter that decides which players clear the evidence bar, and it matters most for the thin-history clubs this step exists to handle. Now 1095L, asserted by a test.

**My Elo drift guard was too narrow.** 12d re-derives `final_elos` by duplicating step 3's `compute_match_elos()` call, because step 3 never persists the team-state vector a relegated cohort needs. I'd asserted `k`/`home_advantage`/`initial_elo` match; the reviewer noted `use_venue_factor` was uncovered — and it has already been flipped once, so it demonstrably changes. Now covered, matching the argument rather than any mention.

**The measurement had no harness.** Fixed as above.

## Verification

- **Full suite: 7,957 pass, 0 fail.** 82 in this step's own file.
- All five guards mutation-tested individually, plus both drift guards: retuning step 3's `ELO_HOME_ADV` to 92 fails the Elo guard; the `lookback_days` assertion fails if it drifts.
- Seeding verified against the live `predictions-latest` release: exactly two teams have NA Elo in the real fixture window, matching the premise and no others.

## Not verified

**No live pipeline run** — it needs multi-GB lineups and career-panna data. So the sanity check that matters most is outstanding: *do the strongest clubs in Europe come out on top?* Structure guards can't catch a collapsed scale or a flipped sign. Worth eyeballing `rank_tiento` on the first real run before the blog switches over.

**The bias-by-cut check `C:\dev\CLAUDE.md` now asks for is also outstanding** for the seeded-vs-earned cut — production has exactly 2 seeded teams, far below a usable sample. That's the "thin cut, ignore it" case rather than a skipped step, and the agent declined to fabricate it from a 9-team synthetic fixture. The domestic-vs-cup-only cut has ~200 each side and should be run once real data exists.

Refs #193. Blog spec: `inthegame-blog/docs/plans/DOMESTIC-TIENTO-2026-08-21.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01533D7gX5RBR78vJbjFL4Yo