### PR TITLE
Key domestic Tiento squad join on team_id, not club name

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: panna
 Title: Player Rating System for Football Using RAPM, SPM, and EPV Methods
-Version: 0.3.30
+Version: 0.3.32
 Authors@R:
     person("Pete", "Owen", , "pete.owen1@hotmail.co.uk", role = c("aut", "cre", "cph"))
 Description: Implements player ratings for football (soccer) from 'Opta'

--- a/NEWS.md
+++ b/NEWS.md
@@ -39,8 +39,21 @@ new guard is structural instead -- one row of the export is one club, so its
 lineup slice must contain exactly one `team_id` -- and cannot be fooled by a
 merge that happens to look plausible.
 
-Three regression tests cover the merge, the spelling mismatch, and the
-fallback path; all three were confirmed to fail with the fix reverted.
+Two rounds of review found the fallback path itself had a residual gap: a
+`team_id` present on the fixture side but absent from `opta_lineups.parquet`
+(a scrape-lag case `01_fixture_results.R` already calls "the silent
+split-identity risk") was falling back to a plain name join -- which could
+silently match a *different* real club sharing that name, since only one id
+is present in that slice and the multi-id structural guard can't see a
+single-id wrong match. Fixed by treating an unresolved (but present) id as
+"no lineups for this club" rather than attempting a name match, so it hits
+the min-squad guard instead of publishing quietly. A second gap -- `.pick_one()`
+silently discarding a team_id split within a single league, with no log line
+-- is now reported before it's collapsed.
+
+Four regression tests cover the merge, the spelling mismatch, the
+name-fallback path, and the unresolved-id case; all four were confirmed to
+fail with the fix reverted.
 
 Version heading realigned to `DESCRIPTION` (0.3.32); the intervening bumps
 came from the PR hook without their own NEWS sections.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,50 @@
-# panna 0.3.28 (dev)
+# panna 0.3.32 (dev)
+
+## Domestic Tiento squads join on team_id, not club name (panna#193 follow-up)
+
+The first live run of step 12d (2026-08-23) refused to publish, and it was
+right to. Two clubs came back with **zero** players and the min-squad guard
+stopped the export. Both symptoms traced to one cause: the squad join was
+keyed on club NAME, and Opta reuses names freely across competitions and
+countries.
+
+It was wrong in both directions at once.
+
+*Too much.* `Liverpool` matches three Opta clubs -- Liverpool FC, Liverpool FC
+Women (WSL) and Liverpool FC Montevideo. Inside the 1095-day window that built
+a **168-player** squad against a real 69, roughly a quarter of it the women's
+team. `Arsenal` was 155 against 73 (Arsenal WFC + Arsenal de Sarandi) and
+`Everton` 155 against 63. Since Tiento is a minutes-weighted mean of player
+ratings, this dragged exactly the biggest clubs on the site toward whatever
+the other clubs were worth. 59 club names in `opta_lineups.parquet` map to
+more than one `team_id`, covering 5.4% of all lineup rows.
+
+*Too little.* Fixtures spell clubs `Le Mans FC` and `SV 07 Elversberg` where
+lineups say `Le Mans` and `Elversberg`, so those two squads resolved to
+nothing. These were the visible failure.
+
+Fixed by carrying `team_id` from `01_fixture_results.rds` (step 01 already
+backfills it, its section 6b) through `.classify_team_leagues()` and keying
+the `opta_lineups` slice on it. The name to filter on is now taken from the
+lineups slice itself, since `build_team_expected_minutes()` matches on
+`team_name` internally and the two sources spell clubs differently. A team
+with no usable id still falls back to the name join, but says so in the log
+rather than merging silently.
+
+Worth recording how the guard behaved, because it shaped the fix: the
+min-squad floor caught the two empty squads and was structurally blind to the
+merged ones, which are far more damaging. A merged squad has MORE players and
+reads as healthier than a correct one, so no size threshold can catch it. The
+new guard is structural instead -- one row of the export is one club, so its
+lineup slice must contain exactly one `team_id` -- and cannot be fooled by a
+merge that happens to look plausible.
+
+Three regression tests cover the merge, the spelling mismatch, and the
+fallback path; all three were confirmed to fail with the fix reverted.
+
+Version heading realigned to `DESCRIPTION` (0.3.32); the intervening bumps
+came from the PR hook without their own NEWS sections.
+
 
 ## Tiento for every domestic + cup club, not just the World Cup 48 (panna#193)
 

--- a/data-raw/match-predictions-opta/12d_export_domestic_team_strength.R
+++ b/data-raw/match-predictions-opta/12d_export_domestic_team_strength.R
@@ -44,9 +44,11 @@ if (!exists("domestic_codes")) {
 }
 if (!exists("cup_codes")) cup_codes <- PANNA_LEAGUE_GROUPS$continental
 if (!exists("as_of_domestic")) as_of_domestic <- Sys.Date()
-# Below this, a squad is not a small roster -- it is a broken team_name join
-# (announced_name mismatch, opta_lineups drift). 26-man cap makes even a
-# genuinely thin squad clear the bar comfortably.
+# Below this, a squad is not a small roster -- the squad join found nothing.
+# Since the join is keyed on team_id (section 4), that means opta_lineups has
+# no rows for this club at all, not a spelling mismatch: a club promoted from
+# a division panna does not scrape has an Elo seed but no players. 26-man cap
+# makes even a genuinely thin squad clear the bar comfortably.
 if (!exists("MIN_PLAUSIBLE_SQUAD_N")) MIN_PLAUSIBLE_SQUAD_N <- 5L
 
 TIENTO_WEIGHTS <- c(panna = 0.40, epr = 0.20, elo = 0.30, psr = 0.10)  # DO NOT re-fit; 12_export_wc2026_blog.R:359 is the one derivation
@@ -80,19 +82,32 @@ message("\n=== Exporting domestic + cup team strength (Tiento, all clubs) ===\n"
   scope <- c(domestic_codes, cup_codes)
   fr <- fr[league %in% scope]
   if (nrow(fr) == 0L) {
-    return(data.table::data.table(team = character(0), league = character(0),
+    return(data.table::data.table(team = character(0), team_id = character(0),
+                                   league = character(0),
                                    is_domestic_league = logical(0), cur_sey = numeric(0)))
   }
   cur_sey_by_league <- fr[, .(cur_sey = max(season_end_year, na.rm = TRUE)), by = league]
   fr <- merge(fr, cur_sey_by_league, by = "league")
   fr <- fr[season_end_year == cur_sey]
 
+  # team_id, not just team NAME. Opta reuses club names across competitions and
+  # countries: "Liverpool" is Liverpool FC, Liverpool FC Women (WSL) and
+  # Liverpool FC Montevideo; "Arsenal" is Arsenal FC, Arsenal WFC and Arsenal de
+  # Sarandi. Keying the squad join on the name merged all of them into one
+  # 168-player "Liverpool" (vs 69 real), about a quarter of it the women's
+  # squad -- see the id-keyed join in section 4. Step 01 backfills these ids
+  # (its section 6b), but tolerate their absence rather than dropping teams:
+  # a NA id falls back to the name join and is logged, never silently merged.
+  .id_col <- function(nm) if (nm %in% names(fr)) fr[[nm]] else NA_character_
   rows <- data.table::rbindlist(list(
-    fr[, .(team = home_team, league, cur_sey)],
-    fr[, .(team = away_team, league, cur_sey)]
+    fr[, .(team = home_team, team_id = .id_col("home_team_id"), league, cur_sey)],
+    fr[, .(team = away_team, team_id = .id_col("away_team_id"), league, cur_sey)]
   ))
   rows <- rows[!is.na(team) & nzchar(team)]
-  tally <- rows[, .N, by = .(team, league, cur_sey)]
+  rows[is.na(team_id) | !nzchar(team_id), team_id := NA_character_]
+  # Grouping by team_id as well splits a shared name into its real clubs; the
+  # modal-row pick below then keeps the one this league actually means.
+  tally <- rows[, .N, by = .(team, team_id, league, cur_sey)]
 
   is_dom_league <- tally$league %in% domestic_codes
   dom <- tally[is_dom_league]
@@ -109,7 +124,10 @@ message("\n=== Exporting domestic + cup team strength (Tiento, all clubs) ===\n"
   dom1 <- .pick_one(dom)
   cup1 <- .pick_one(cup)
 
-  multi_dom <- dom[, .N, by = team][N > 1L]
+  # uniqueN(league), not .N: now that the tally is split by team_id too, a
+  # single club with two ids in ONE league would otherwise read as "matched >1
+  # domestic league" and print a note about a thing that did not happen.
+  multi_dom <- dom[, .(n_lg = data.table::uniqueN(league)), by = team][n_lg > 1L]
   if (nrow(multi_dom) > 0L) {
     message(sprintf(
       "  NOTE: %d team(s) matched >1 domestic league this season (kept the most-frequent): %s",
@@ -121,8 +139,8 @@ message("\n=== Exporting domestic + cup team strength (Tiento, all clubs) ===\n"
   cup_only <- cup1[!team %in% dom_teams]
 
   out <- data.table::rbindlist(list(
-    dom1[, .(team, league, is_domestic_league = TRUE, cur_sey)],
-    cup_only[, .(team, league, is_domestic_league = FALSE, cur_sey)]
+    dom1[, .(team, team_id, league, is_domestic_league = TRUE, cur_sey)],
+    cup_only[, .(team, team_id, league, is_domestic_league = FALSE, cur_sey)]
   ))
   out
 }
@@ -282,7 +300,8 @@ message("\n=== Exporting domestic + cup team strength (Tiento, all clubs) ===\n"
   small_squads <- dt[squad_n < min_squad_n]
   if (nrow(small_squads) > 0L) {
     stop(sprintf(paste("domestic_team_strength: %d team(s) have implausibly small squads",
-                       "(<%d players -- broken team_name join, not a small squad): %s"),
+                       "(<%d players -- the team_id squad join found no lineups for them,",
+                       "not a genuinely small squad): %s"),
                  nrow(small_squads), min_squad_n,
                  paste(sprintf("%s(%d)", small_squads$team, small_squads$squad_n), collapse = ", ")),
          call. = FALSE)
@@ -376,10 +395,11 @@ if (!file.exists(lineups_path)) {
 }
 lu_all <- as.data.table(read_parquet(
   lineups_path,
-  col_select = c("team_name", "match_id", "match_date", "player_id",
+  col_select = c("team_id", "team_name", "match_id", "match_date", "player_id",
                 "player_name", "position", "is_starter", "minutes_played",
                 "competition")))
-data.table::setkey(lu_all, team_name)
+data.table::setkey(lu_all, team_id)
+lu_known_ids <- unique(lu_all$team_id)
 lu_known_teams <- unique(lu_all$team_name)
 
 cp_path <- file.path(opta_data_dir(), "career_panna.parquet")
@@ -419,10 +439,39 @@ sq_epr <- {
 .wsum <- function(x, w) sum(w * data.table::fifelse(is.na(x), 0, x))
 
 teams <- team_league$team
+team_ids <- team_league$team_id
+name_fallback <- character(0)   # teams resolved by name because no id was available
 agg_rows <- vector("list", length(teams))
 for (i in seq_along(teams)) {
-  tm <- teams[i]
-  lu_team <- if (tm %in% lu_known_teams) lu_all[.(tm)] else lu_all[0L]
+  tm  <- teams[i]
+  tid <- team_ids[i]
+  if (!is.na(tid) && nzchar(tid) && tid %in% lu_known_ids) {
+    lu_team <- lu_all[.(tid)]
+  } else {
+    # No usable id: fall back to the old name join, but SAY SO. This is the
+    # path that silently merged clubs before, so it must never be invisible.
+    lu_team <- if (tm %in% lu_known_teams) lu_all[team_name == tm] else lu_all[0L]
+    name_fallback <- c(name_fallback, tm)
+  }
+  # Structural, not a magic threshold: one row of this export is one club, so
+  # its lineup slice must contain exactly one team_id. A size ceiling would
+  # have to guess where a real squad ends and a merged one begins; this cannot
+  # be fooled by a merge that happens to look plausible.
+  if (nrow(lu_team) > 0L && data.table::uniqueN(lu_team$team_id) > 1L) {
+    stop(sprintf(paste("domestic_team_strength: squad slice for %s covers %d distinct",
+                       "team_id(s) (%s) -- distinct clubs sharing a name have been",
+                       "merged into one squad. Refusing to publish."),
+                 tm, data.table::uniqueN(lu_team$team_id),
+                 paste(utils::head(unique(lu_team$team_id), 4L), collapse = ", ")),
+         call. = FALSE)
+  }
+  # The NAME to filter on comes from the lineups slice, not from the fixture
+  # side. build_team_expected_minutes() does `lineups[team_name == team]`
+  # internally, and the two sources spell clubs differently -- fixtures say
+  # "Le Mans FC" and "SV 07 Elversberg" where lineups say "Le Mans" and
+  # "Elversberg". Passing the fixture spelling emptied both squads to 0
+  # players, which is what the min-squad guard caught on the 2026-08-23 run.
+  em_team <- if (nrow(lu_team) > 0L) lu_team$team_name[1L] else tm
   # lookback_days = 1095L, NOT the 730L library default. announced_squads.R
   # passes 1095 at both of its build_team_expected_minutes() call sites, so
   # taking the default here would have quietly made domestic Tiento mean
@@ -432,7 +481,7 @@ for (i in seq_along(teams)) {
   # bar, which matters most for exactly the thin-history clubs this step
   # handles specially.
   em <- panna::build_team_expected_minutes(
-    team = tm, lineups = lu_team, as_of = as_of_domestic,
+    team = em_team, lineups = lu_team, as_of = as_of_domestic,
     international_only = FALSE, lookback_days = 1095L
   )
   if (is.null(em) || nrow(em) == 0L || !"player_id" %in% names(em)) {
@@ -461,6 +510,15 @@ for (i in seq_along(teams)) {
   )
 }
 agg <- data.table::rbindlist(agg_rows)
+
+message(sprintf("  Squad join: %d/%d team(s) resolved by team_id",
+                length(teams) - length(name_fallback), length(teams)))
+if (length(name_fallback) > 0L) {
+  message(sprintf(paste("  NOTE: %d team(s) had no usable team_id and fell back to the",
+                        "NAME join -- these are the only rows where distinct clubs",
+                        "sharing a name could still merge: %s"),
+                  length(name_fallback), paste(name_fallback, collapse = ", ")))
+}
 
 strength <- merge(team_league, agg, by = "team", all.x = TRUE)
 for (m in c("panna", "offense", "defense", "epr", "psr", "elo")) {

--- a/data-raw/match-predictions-opta/12d_export_domestic_team_strength.R
+++ b/data-raw/match-predictions-opta/12d_export_domestic_team_strength.R
@@ -121,12 +121,32 @@ message("\n=== Exporting domestic + cup team strength (Tiento, all clubs) ===\n"
     data.table::setorder(dt, team, -N, league)
     dt[, .SD[1L], by = team]
   }
+  # .pick_one() keeps only the highest-N (team, team_id) row per team, so a
+  # club with two DIFFERENT ids inside the SAME league (a mid-season Opta id
+  # change, or a partial team_id backfill in 01_fixture_results.rds) has its
+  # minority id silently discarded -- with no trace that it happened. That
+  # matters here specifically because the discarded id might be the one that
+  # actually resolves against opta_lineups.parquet's team_id, in which case
+  # a wrong-but-plausible-looking squad would be exactly as silent as the
+  # merge this whole step_id rework exists to catch. Log it before picking.
+  .log_split_ids <- function(dt, pool_label) {
+    split_id <- dt[, .(n_id = data.table::uniqueN(team_id)), by = .(team, league)][n_id > 1L]
+    if (nrow(split_id) > 0L) {
+      message(sprintf(
+        "  NOTE: %d team(s) have >1 team_id within one %s league (kept the most-frequent id): %s",
+        nrow(split_id), pool_label, paste(split_id$team, collapse = ", ")))
+    }
+  }
+  .log_split_ids(dom, "domestic")
+  .log_split_ids(cup, "cup")
+
   dom1 <- .pick_one(dom)
   cup1 <- .pick_one(cup)
 
   # uniqueN(league), not .N: now that the tally is split by team_id too, a
   # single club with two ids in ONE league would otherwise read as "matched >1
-  # domestic league" and print a note about a thing that did not happen.
+  # domestic league" and print a note about a thing that did not happen --
+  # that specific case is what .log_split_ids() above reports instead.
   multi_dom <- dom[, .(n_lg = data.table::uniqueN(league)), by = team][n_lg > 1L]
   if (nrow(multi_dom) > 0L) {
     message(sprintf(
@@ -440,18 +460,37 @@ sq_epr <- {
 
 teams <- team_league$team
 team_ids <- team_league$team_id
-name_fallback <- character(0)   # teams resolved by name because no id was available
+# Two DIFFERENT conditions land in a name-join fallback, and 01_fixture_results.R
+# (section 6b) already names the second one as worth a loud warning on its own:
+# a fixture team_id absent from opta_lineups' team_id set is "the silent
+# split-identity risk" -- a promoted team that hasn't played yet, about to
+# start producing a lineup variant once it does. Conflating it with "this team
+# simply has no team_id" would bury exactly the signal step 01 already flags.
+no_id <- character(0)          # tid is NA/empty -- no id on the fixture side at all
+unresolved_id <- character(0)  # tid is present but absent from opta_lineups' ids
 agg_rows <- vector("list", length(teams))
 for (i in seq_along(teams)) {
   tm  <- teams[i]
   tid <- team_ids[i]
-  if (!is.na(tid) && nzchar(tid) && tid %in% lu_known_ids) {
+  has_id <- !is.na(tid) && nzchar(tid)
+  if (has_id && tid %in% lu_known_ids) {
     lu_team <- lu_all[.(tid)]
+  } else if (has_id) {
+    # tid EXISTS but is not among opta_lineups' ids -- 01_fixture_results.R
+    # names this "the silent split-identity risk" and warns loudly on it for
+    # a reason: falling back to a name join here can silently match a
+    # DIFFERENT real club that happens to share this name, because only ONE
+    # id is present in that slice -- the structural >1-team_id guard below
+    # cannot see a single-id wrong match. Do NOT attempt the name join; treat
+    # this exactly like "no lineups for this club" (empty squad), which the
+    # min-squad guard is built to catch and refuse to publish.
+    lu_team <- lu_all[0L]
+    unresolved_id <- c(unresolved_id, tm)
   } else {
-    # No usable id: fall back to the old name join, but SAY SO. This is the
-    # path that silently merged clubs before, so it must never be invisible.
+    # No id at all: the name join is the only option, and it is the
+    # documented, intentional degrade path -- but still SAY SO.
     lu_team <- if (tm %in% lu_known_teams) lu_all[team_name == tm] else lu_all[0L]
-    name_fallback <- c(name_fallback, tm)
+    no_id <- c(no_id, tm)
   }
   # Structural, not a magic threshold: one row of this export is one club, so
   # its lineup slice must contain exactly one team_id. A size ceiling would
@@ -511,13 +550,24 @@ for (i in seq_along(teams)) {
 }
 agg <- data.table::rbindlist(agg_rows)
 
+n_fallback <- length(no_id) + length(unresolved_id)
 message(sprintf("  Squad join: %d/%d team(s) resolved by team_id",
-                length(teams) - length(name_fallback), length(teams)))
-if (length(name_fallback) > 0L) {
-  message(sprintf(paste("  NOTE: %d team(s) had no usable team_id and fell back to the",
+                length(teams) - n_fallback, length(teams)))
+if (length(no_id) > 0L) {
+  message(sprintf(paste("  NOTE: %d team(s) have no team_id at all and fell back to the",
                         "NAME join -- these are the only rows where distinct clubs",
                         "sharing a name could still merge: %s"),
-                  length(name_fallback), paste(name_fallback, collapse = ", ")))
+                  length(no_id), paste(no_id, collapse = ", ")))
+}
+if (length(unresolved_id) > 0L) {
+  message(sprintf(paste("  WARNING: %d team(s) have a team_id that does NOT appear in",
+                        "opta_lineups.parquet -- treated as having no lineups (squad_n=0)",
+                        "rather than risking a name-join match against a different club.",
+                        "This is 01_fixture_results.R's 'silent split-identity risk' (a",
+                        "team_id namespace drift between fixtures and lineups, not a",
+                        "missing id) -- expect the min-squad guard to abort on these unless",
+                        "opta_lineups.parquet is refreshed: %s"),
+                  length(unresolved_id), paste(unresolved_id, collapse = ", ")))
 }
 
 strength <- merge(team_league, agg, by = "team", all.x = TRUE)

--- a/tests/testthat/test-domestic-team-strength.R
+++ b/tests/testthat/test-domestic-team-strength.R
@@ -318,7 +318,7 @@ test_that("guard: a 2-player squad is a broken join, not a small squad", {
 
   bad <- data.table::copy(good)
   bad$squad_n[1] <- 2L
-  expect_error(e$.validate_domestic_strength(bad, min_squad_n = 5L), "broken team_name join")
+  expect_error(e$.validate_domestic_strength(bad, min_squad_n = 5L), "found no lineups for them")
 
   expect_no_error(suppressMessages(e$.validate_domestic_strength(good, min_squad_n = 5L)))
 })
@@ -393,7 +393,8 @@ test_that("guard: panna/epr/psr zero (or all-NA) for >=50% of teams refuses to p
   for (tm in teams) {
     for (j in 1:4) {
       lu_rows[[length(lu_rows) + 1L]] <- data.frame(
-        team_name = tm, match_id = paste0("lu_", tm), match_date = "2026-09-01T00:00:00Z",
+        team_id = paste0("id_", tm), team_name = tm,
+        match_id = paste0("lu_", tm), match_date = "2026-09-01T00:00:00Z",
         player_id = sprintf("p%03d", pid), player_name = sprintf("Player %d", pid),
         position = c("Goalkeeper", "Centre Back", "Central Midfielder", "Striker")[j],
         is_starter = TRUE, minutes_played = 90L, competition = "Domestic",
@@ -539,7 +540,7 @@ test_that("12d aborts rather than shipping a team with an impossible squad (inte
   arrow::write_parquet(lu, file.path(opta_dir, "opta_lineups.parquet"))
 
   expect_error(.run_12d(cache_dir, opta_dir, skills_dir, publish = FALSE),
-              "broken team_name join")
+              "found no lineups for them")
 })
 
 
@@ -616,4 +617,97 @@ test_that("12d asks build_team_expected_minutes for the same window the WC path 
   expect_true(all(grepl("1095", wc_windows)))
   expect_true(any(grepl("lookback_days = 1095L",
                         readLines(step12d, warn = FALSE), fixed = TRUE)))
+})
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for the 2026-08-23 team_name-join bug (found on the first
+# live run of 12d). Opta reuses club names across competitions and countries,
+# so a name-keyed squad join is wrong in BOTH directions at once:
+#   too much -- "Liverpool" matched Liverpool FC + Liverpool FC Women (WSL) +
+#     Liverpool FC Montevideo, giving a 168-player squad against a real 69,
+#     about a quarter of it the women's team. Arsenal and Everton the same.
+#   too little -- fixtures spell clubs "Le Mans FC" / "SV 07 Elversberg" where
+#     opta_lineups says "Le Mans" / "Elversberg", so those squads came back
+#     EMPTY and the min-squad guard blocked the publish.
+# Both are fixed by keying the join on team_id. The min-squad guard only ever
+# caught the second kind; the first inflates squad_n and looks healthier than
+# a correct squad, which is why it needs a test rather than a threshold.
+# ---------------------------------------------------------------------------
+
+test_that("a second club sharing a team NAME does not merge into the squad", {
+  skip_if_not_installed("arrow")
+  local_no_reload()
+  cache_dir <- withr::local_tempdir()
+  opta_dir <- withr::local_tempdir()
+  skills_dir <- withr::local_tempdir()
+  .dts_full_fixture(cache_dir, opta_dir, skills_dir)
+  on.exit(suppressWarnings(rm("publish_files", envir = globalenv())), add = TRUE)
+
+  lu_path <- file.path(opta_dir, "opta_lineups.parquet")
+  lu <- as.data.frame(arrow::read_parquet(lu_path, mmap = FALSE))
+  # The "TeamA Women" case: same team_name, different club, different id.
+  intruder <- lu[lu$team_id == "id_TeamA", ]
+  intruder$team_id    <- "id_TeamA_WOMEN"
+  intruder$match_id   <- paste0(intruder$match_id, "_w")
+  intruder$player_id  <- paste0(intruder$player_id, "_w")
+  arrow::write_parquet(rbind(lu, intruder), lu_path)
+
+  .run_12d(cache_dir, opta_dir, skills_dir)
+  out <- as.data.frame(arrow::read_parquet(file.path(cache_dir, "team_strength.parquet"),
+                                           mmap = FALSE))
+  # 4, not 8: the intruder's players must not be in TeamA's squad.
+  expect_identical(out$squad_n[out$team == "TeamA"], 4L)
+})
+
+test_that("a club spelled differently in lineups than in fixtures still resolves", {
+  skip_if_not_installed("arrow")
+  local_no_reload()
+  cache_dir <- withr::local_tempdir()
+  opta_dir <- withr::local_tempdir()
+  skills_dir <- withr::local_tempdir()
+  .dts_full_fixture(cache_dir, opta_dir, skills_dir)
+  on.exit(suppressWarnings(rm("publish_files", envir = globalenv())), add = TRUE)
+
+  lu_path <- file.path(opta_dir, "opta_lineups.parquet")
+  lu <- as.data.frame(arrow::read_parquet(lu_path, mmap = FALSE))
+  # Fixtures call it "TeamC"; lineups call it "TeamC FC" -- the Le Mans shape.
+  lu$team_name[lu$team_id == "id_TeamC"] <- "TeamC FC"
+  arrow::write_parquet(lu, lu_path)
+
+  .run_12d(cache_dir, opta_dir, skills_dir)
+  out <- as.data.frame(arrow::read_parquet(file.path(cache_dir, "team_strength.parquet"),
+                                           mmap = FALSE))
+  # Full squad despite the spelling difference; pre-fix this was 0 and the
+  # min-squad guard aborted the whole step.
+  expect_identical(out$squad_n[out$team == "TeamC"], 4L)
+})
+
+test_that("the name-fallback path refuses to merge two clubs into one squad", {
+  # The one route by which a merge can still happen: a team whose fixture rows
+  # carry no team_id falls back to the name join. That path must abort, not
+  # publish a merged squad.
+  skip_if_not_installed("arrow")
+  local_no_reload()
+  cache_dir <- withr::local_tempdir()
+  opta_dir <- withr::local_tempdir()
+  skills_dir <- withr::local_tempdir()
+  .dts_full_fixture(cache_dir, opta_dir, skills_dir)
+  on.exit(suppressWarnings(rm("publish_files", envir = globalenv())), add = TRUE)
+
+  fr <- readRDS(file.path(cache_dir, "01_fixture_results.rds"))
+  fr$home_team_id[fr$home_team == "TeamA"] <- NA_character_
+  fr$away_team_id[fr$away_team == "TeamA"] <- NA_character_
+  saveRDS(fr, file.path(cache_dir, "01_fixture_results.rds"))
+
+  lu_path <- file.path(opta_dir, "opta_lineups.parquet")
+  lu <- as.data.frame(arrow::read_parquet(lu_path, mmap = FALSE))
+  intruder <- lu[lu$team_id == "id_TeamA", ]
+  intruder$team_id   <- "id_TeamA_WOMEN"
+  intruder$match_id  <- paste0(intruder$match_id, "_w")
+  intruder$player_id <- paste0(intruder$player_id, "_w")
+  arrow::write_parquet(rbind(lu, intruder), lu_path)
+
+  expect_error(.run_12d(cache_dir, opta_dir, skills_dir),
+               "distinct clubs sharing a name")
 })

--- a/tests/testthat/test-domestic-team-strength.R
+++ b/tests/testthat/test-domestic-team-strength.R
@@ -711,3 +711,43 @@ test_that("the name-fallback path refuses to merge two clubs into one squad", {
   expect_error(.run_12d(cache_dir, opta_dir, skills_dir),
                "distinct clubs sharing a name")
 })
+
+
+test_that("an unresolved (present-but-unmatched) team_id does not fall back to a name match against a same-named club", {
+  # Code-review finding on the team_id fix: a team_id that EXISTS on the
+  # fixture side but is absent from opta_lineups.parquet (e.g. this club's
+  # matches haven't been scraped yet -- 01_fixture_results.R's own "silent
+  # split-identity risk") must NOT fall back to a plain team_name join. If it
+  # did, and another real club shares the name, the wrong club's players
+  # would be silently priced in -- and the >1-team_id structural guard cannot
+  # catch it, because only ONE id is present in that slice. The safe behavior
+  # is to treat it as squad_n = 0 and let the min-squad guard abort.
+  skip_if_not_installed("arrow")
+  local_no_reload()
+  cache_dir <- withr::local_tempdir()
+  opta_dir <- withr::local_tempdir()
+  skills_dir <- withr::local_tempdir()
+  .dts_full_fixture(cache_dir, opta_dir, skills_dir)
+  on.exit(suppressWarnings(rm("publish_files", envir = globalenv())), add = TRUE)
+
+  # Give TeamB a fixture-side id that opta_lineups has never heard of.
+  fr <- readRDS(file.path(cache_dir, "01_fixture_results.rds"))
+  fr$home_team_id[fr$home_team == "TeamB"] <- "id_TeamB_NOT_IN_LINEUPS"
+  fr$away_team_id[fr$away_team == "TeamB"] <- "id_TeamB_NOT_IN_LINEUPS"
+  saveRDS(fr, file.path(cache_dir, "01_fixture_results.rds"))
+
+  # A DIFFERENT real club that happens to share TeamB's name -- the trap a
+  # name-join fallback would fall into.
+  lu_path <- file.path(opta_dir, "opta_lineups.parquet")
+  lu <- as.data.frame(arrow::read_parquet(lu_path, mmap = FALSE))
+  intruder <- lu[lu$team_id == "id_TeamC", ]
+  intruder$team_id    <- "id_TeamB_IMPOSTOR"
+  intruder$team_name  <- "TeamB"
+  intruder$match_id   <- paste0(intruder$match_id, "_impostor")
+  intruder$player_id  <- paste0(intruder$player_id, "_impostor")
+  arrow::write_parquet(rbind(lu, intruder), lu_path)
+
+  # squad_n < MIN_PLAUSIBLE_SQUAD_N (3L in this harness) must abort, NOT
+  # silently publish the impostor's 4-player squad under TeamB.
+  expect_error(.run_12d(cache_dir, opta_dir, skills_dir), "found no lineups for them")
+})


### PR DESCRIPTION
## Summary
- First live run of step 12d (2026-08-23) refused to publish: `Le Mans FC` and `SV 07 Elversberg` came back with 0 lineup rows, tripping the min-squad guard.
- Investigating traced the real bug wider than the two visible failures: the squad join was keyed on `team_name`, and Opta reuses club names across competitions/countries. `Liverpool` matched 3 clubs (men's, WSL women's, Liverpool Montevideo) and built a 168-player squad against a real 69; Arsenal and Everton the same shape. 59 club names in `opta_lineups.parquet` map to >1 `team_id`, covering 5.4% of all lineup rows.
- Fixed by keying the squad join on `team_id` (carried from `01_fixture_results.rds`, which step 01 already backfills), with a structural guard that aborts if a squad slice ever spans >1 distinct `team_id`.
- Two rounds of `pr-review-toolkit` review (code-reviewer + silent-failure-hunter, both Sonnet-forced) found and fixed a residual gap: an id present on the fixture side but absent from lineups was still falling back to a name join, which could silently match a *different* real club since the multi-id guard can't see a single-id wrong match. Now treated as "no lineups" and caught by the min-squad guard instead.

## Test plan
- [x] Full `devtools::test()` suite: 7964 assertions, 0 failures, 771 tests
- [x] 4 new regression tests (name collision, spelling mismatch, name-fallback merge, unresolved-id impostor) — each confirmed to fail with its corresponding fix reverted (mutation-tested)
- [x] `devtools::document()` not needed — no exported symbols changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_ac2ed4f1-e577-4877-b375-8ab380e58797